### PR TITLE
Add command to set 2.2.0.0 compatibility to worldgen on a per-world basis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1671234391
+//version: 1671313514
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -280,7 +280,9 @@ minecraft {
     runDir = 'run'
 
     if (replaceGradleTokenInFile) {
-        replaceIn replaceGradleTokenInFile
+        for (f in replaceGradleTokenInFile.split(',')) {
+            replaceIn f
+        }
         if (gradleTokenModId) {
             replace gradleTokenModId, modId
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
-//version: 1664303323
+//version: 1671234391
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
- Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/build.gradle for updates.
+ Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/master/build.gradle for updates.
  */
 
 
@@ -31,7 +31,7 @@ buildscript {
             url 'https://maven.minecraftforge.net'
         }
         maven {
-            // GTNH ForgeGradle Fork
+            // GTNH ForgeGradle and ASM Fork
             name = "GTNH Maven"
             url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
@@ -45,7 +45,9 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.9'
+        //Overwrite the current ASM version to fix shading newer than java 8 applicatations.
+        classpath 'org.ow2.asm:asm-debug-all-custom:5.0.3'  
+        classpath 'net.minecraftforge.gradle:ForgeGradle:1.2.13'
     }
 }
 plugins {
@@ -147,17 +149,21 @@ String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
 String kotlinSourceDir = "src/main/kotlin/"
 
-String targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/")
-String targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/")
-String targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/")
+
+final String modGroupPath = modGroup.toString().replaceAll("\\.", "/")
+final String apiPackagePath = apiPackage.toString().replaceAll("\\.", "/")
+
+String targetPackageJava = javaSourceDir + modGroupPath
+String targetPackageScala = scalaSourceDir + modGroupPath
+String targetPackageKotlin = kotlinSourceDir + modGroupPath
 if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
     throw new GradleException("Could not resolve \"modGroup\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
 }
 
 if (apiPackage) {
-    targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
-    targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
-    targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/")
+    targetPackageJava = javaSourceDir + modGroupPath + "/" + apiPackagePath
+    targetPackageScala = scalaSourceDir + modGroupPath + "/" + apiPackagePath
+    targetPackageKotlin = kotlinSourceDir + modGroupPath + "/" + apiPackagePath
     if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
         throw new GradleException("Could not resolve \"apiPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
     }
@@ -171,31 +177,36 @@ if (accessTransformersFile) {
 }
 
 if (usesMixins.toBoolean()) {
-    if (mixinsPackage.isEmpty() || mixinPlugin.isEmpty()) {
-        throw new GradleException("\"mixinPlugin\" requires \"mixinsPackage\" and \"mixinPlugin\" to be set!")
+    if (mixinsPackage.isEmpty()) {
+        throw new GradleException("\"usesMixins\" requires \"mixinsPackage\" to be set!")
     }
+    final String mixinPackagePath = mixinsPackage.toString().replaceAll("\\.", "/")
+    final String mixinPluginPath = mixinPlugin.toString().replaceAll("\\.", "/")
 
-    targetPackageJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
-    targetPackageScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
-    targetPackageKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinsPackage.toString().replaceAll("\\.", "/")
+    targetPackageJava = javaSourceDir + modGroupPath + "/" + mixinPackagePath
+    targetPackageScala = scalaSourceDir + modGroupPath + "/" + mixinPackagePath
+    targetPackageKotlin = kotlinSourceDir + modGroupPath + "/" + mixinPackagePath
     if (!(getFile(targetPackageJava).exists() || getFile(targetPackageScala).exists() || getFile(targetPackageKotlin).exists())) {
         throw new GradleException("Could not resolve \"mixinsPackage\"! Could not find " + targetPackageJava + " or " + targetPackageScala + " or " + targetPackageKotlin)
     }
 
-    String targetFileJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".java"
-    String targetFileScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".scala"
-    String targetFileScalaJava = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".java"
-    String targetFileKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + mixinPlugin.toString().replaceAll("\\.", "/") + ".kt"
-    if (!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
-        throw new GradleException("Could not resolve \"mixinPlugin\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
+    if (!mixinPlugin.isEmpty()) {
+        String targetFileJava = javaSourceDir + modGroupPath + "/" + mixinPluginPath + ".java"
+        String targetFileScala = scalaSourceDir + modGroupPath + "/" + mixinPluginPath + ".scala"
+        String targetFileScalaJava = scalaSourceDir + modGroupPath + "/" + mixinPluginPath + ".java"
+        String targetFileKotlin = kotlinSourceDir + modGroupPath + "/" + mixinPluginPath + ".kt"
+        if (!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
+            throw new GradleException("Could not resolve \"mixinPlugin\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
+        }
     }
 }
 
 if (coreModClass) {
-    String targetFileJava = javaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".java"
-    String targetFileScala = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".scala"
-    String targetFileScalaJava = scalaSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".java"
-    String targetFileKotlin = kotlinSourceDir + modGroup.toString().replaceAll("\\.", "/") + "/" + coreModClass.toString().replaceAll("\\.", "/") + ".kt"
+    final String coreModPath = coreModClass.toString().replaceAll("\\.", "/")
+    String targetFileJava = javaSourceDir + modGroupPath + "/" + coreModPath + ".java"
+    String targetFileScala = scalaSourceDir + modGroupPath + "/" + coreModPath + ".scala"
+    String targetFileScalaJava = scalaSourceDir + modGroupPath + "/" + coreModPath + ".java"
+    String targetFileKotlin = kotlinSourceDir + modGroupPath + "/" + coreModPath + ".kt"
     if (!(getFile(targetFileJava).exists() || getFile(targetFileScala).exists() || getFile(targetFileScalaJava).exists() || getFile(targetFileKotlin).exists())) {
         throw new GradleException("Could not resolve \"coreModClass\"! Could not find " + targetFileJava + " or " + targetFileScala + " or " + targetFileScalaJava + " or " + targetFileKotlin)
     }
@@ -251,7 +262,7 @@ if (project.hasProperty("customArchiveBaseName") && customArchiveBaseName) {
 def arguments = []
 def jvmArguments = []
 
-if (usesMixins.toBoolean() || forceEnableMixins) {
+if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
     arguments += [
         "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
     ]
@@ -316,13 +327,16 @@ repositories {
         name 'Overmind forge repo mirror'
         url 'https://gregtech.overminddl1.com/'
     }
-    if (usesMixins.toBoolean() || forceEnableMixins) {
+    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
         maven {
-            name 'sponge'
-            url 'https://repo.spongepowered.org/repository/maven-public'
+            name = "GTNH Maven"
+            url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         }
-        maven {
-            url 'https://jitpack.io'
+        if (usesMixinDebug.toBoolean()) {
+            maven {
+                name = "Fabric Maven"
+                url = "https://maven.fabricmc.net/"
+            }
         }
     }
 }
@@ -332,19 +346,13 @@ dependencies {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
-        annotationProcessor('org.spongepowered:mixin:0.8-SNAPSHOT')
-    }
-    if (usesMixins.toBoolean() || forceEnableMixins) {
-        // using 0.8 to workaround a issue in 0.7 which fails mixin application
-        compile('com.github.GTNewHorizons:SpongePoweredMixin:0.7.12-GTNH') {
-            // Mixin includes a lot of dependencies that are too up-to-date
-            exclude module: 'launchwrapper'
-            exclude module: 'guava'
-            exclude module: 'gson'
-            exclude module: 'commons-io'
-            exclude module: 'log4j-core'
+        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.3:processor')
+        if (usesMixinDebug.toBoolean()) {
+            runtimeOnly('org.jetbrains:intellij-fernflower:1.2.1.16')
         }
-        compile('com.github.GTNewHorizons:SpongeMixins:1.5.0')
+    }
+    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
+        compile('com.gtnewhorizon:gtnhmixins:2.1.3')
     }
 }
 
@@ -356,13 +364,18 @@ def mixinSrg = "${tasks.reobf.temporaryDir}" + File.separator + "mixins.srg"
 
 task generateAssets {
     if (usesMixins.toBoolean()) {
-        def mixinConfigFile = getFile("/src/main/resources/mixins." + modId + ".json");
+        def mixinConfigFile = getFile("/src/main/resources/mixins." + modId + ".json")
         if (!mixinConfigFile.exists()) {
+            def mixinPluginLine = ""
+            if(!mixinPlugin.isEmpty()) {
+                // We might not have a mixin plugin if we're using early/late mixins
+                mixinPluginLine +=   """\n  "plugin": "${modGroup}.${mixinPlugin}", """
+            }
+
             mixinConfigFile.text = """{
   "required": true,
-  "minVersion": "0.7.11",
-  "package": "${modGroup}.${mixinsPackage}",
-  "plugin": "${modGroup}.${mixinPlugin}",
+  "minVersion": "0.8.5-GTNH",
+  "package": "${modGroup}.${mixinsPackage}",${mixinPluginLine}
   "refmap": "${mixingConfigRefMap}",
   "target": "@env(DEFAULT)",
   "compatibilityLevel": "JAVA_8",
@@ -574,11 +587,11 @@ task devJar(type: Jar) {
 
 task apiJar(type: Jar) {
     from(sourceSets.main.allSource) {
-        include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
+        include modGroupPath + "/" + apiPackagePath + '/**'
     }
 
     from(sourceSets.main.output) {
-        include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
+        include modGroupPath + "/" + apiPackagePath + '/**'
     }
 
     from(sourceSets.main.resources.srcDirs) {
@@ -662,10 +675,10 @@ publishing {
     }
 }
 
-if (modrinthProjectId.size() != 0) {
+if (modrinthProjectId.size() != 0 && System.getenv("MODRINTH_TOKEN") != null) {
     apply plugin: 'com.modrinth.minotaur'
 
-    File changelogFile = new File("CHANGELOG.md")
+    File changelogFile = new File(System.getenv("CHANGELOG_FILE") ?: "CHANGELOG.md")
 
     modrinth {
         token = System.getenv("MODRINTH_TOKEN")
@@ -691,14 +704,17 @@ if (modrinthProjectId.size() != 0) {
             addModrinthDep(qual[0], qual[1], parts[1])
         }
     }
+    if (usesMixins.toBoolean()) {
+        addModrinthDep("required", "project", "gtnhmixins")
+    }
     tasks.modrinth.dependsOn(build)
     tasks.publish.dependsOn(tasks.modrinth)
 }
 
-if (curseForgeProjectId.size() != 0) {
+if (curseForgeProjectId.size() != 0 && System.getenv("CURSEFORGE_TOKEN") != null) {
     apply plugin: 'com.matthewprenger.cursegradle'
 
-    File changelogFile = new File("CHANGELOG.md")
+    File changelogFile = new File(System.getenv("CHANGELOG_FILE") ?: "CHANGELOG.md")
 
     curseforge {
         apiKey = System.getenv("CURSEFORGE_TOKEN")
@@ -731,6 +747,9 @@ if (curseForgeProjectId.size() != 0) {
             String[] parts = dep.split(":")
             addCurseForgeRelation(parts[0], parts[1])
         }
+    }
+    if (usesMixins.toBoolean()) {
+        addCurseForgeRelation("requiredDependency", "gtnhmixins")
     }
     tasks.curseforge.dependsOn(build)
     tasks.publish.dependsOn(tasks.curseforge)

--- a/src/main/java/rwg/RWG.java
+++ b/src/main/java/rwg/RWG.java
@@ -1,5 +1,6 @@
 package rwg;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.Mod.Instance;
@@ -12,9 +13,11 @@ import net.minecraft.command.ServerCommandManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.MinecraftForge;
 import rwg.biomes.base.BaseBiomes;
+import rwg.commands.RwgBugInfoCommand;
 import rwg.commands.RwgNoiseCommand;
 import rwg.config.ConfigRWG;
 import rwg.data.VillageMaterials;
+import rwg.handlers.LoginHandler;
 import rwg.support.Support;
 import rwg.world.WorldTypeRealistic;
 
@@ -33,6 +36,8 @@ public class RWG {
         BaseBiomes.load();
 
         MinecraftForge.TERRAIN_GEN_BUS.register(new VillageMaterials());
+
+        FMLCommonHandler.instance().bus().register(new LoginHandler());
         // MinecraftForge.TERRAIN_GEN_BUS.register(new TreeReplacement());
     }
 
@@ -51,5 +56,6 @@ public class RWG {
         ServerCommandManager manager = (ServerCommandManager) command;
 
         manager.registerCommand(new RwgNoiseCommand());
+        manager.registerCommand(new RwgBugInfoCommand());
     }
 }

--- a/src/main/java/rwg/RWG.java
+++ b/src/main/java/rwg/RWG.java
@@ -6,8 +6,13 @@ import cpw.mods.fml.common.Mod.Instance;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.event.FMLServerStartingEvent;
+import net.minecraft.command.ICommandManager;
+import net.minecraft.command.ServerCommandManager;
+import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.MinecraftForge;
 import rwg.biomes.base.BaseBiomes;
+import rwg.commands.RwgNoiseCommand;
 import rwg.config.ConfigRWG;
 import rwg.data.VillageMaterials;
 import rwg.support.Support;
@@ -37,5 +42,14 @@ public class RWG {
     @EventHandler
     public void postInit(FMLPostInitializationEvent event) {
         Support.init();
+    }
+
+    @EventHandler
+    public void serverStart(FMLServerStartingEvent event) {
+        MinecraftServer server = event.getServer();
+        ICommandManager command = server.getCommandManager();
+        ServerCommandManager manager = (ServerCommandManager) command;
+
+        manager.registerCommand(new RwgNoiseCommand());
     }
 }

--- a/src/main/java/rwg/biomes/realistic/RealisticBiomeBase.java
+++ b/src/main/java/rwg/biomes/realistic/RealisticBiomeBase.java
@@ -31,7 +31,7 @@ import rwg.biomes.realistic.savanna.RealisticBiomeSavannaForest;
 import rwg.biomes.realistic.savanna.RealisticBiomeStoneMountains;
 import rwg.biomes.realistic.savanna.RealisticBiomeStoneMountainsCactus;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 import rwg.world.ChunkManagerRealistic;
 
 public class RealisticBiomeBase {
@@ -147,7 +147,7 @@ public class RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {}
@@ -161,7 +161,7 @@ public class RealisticBiomeBase {
             Random mapRand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float noise[]) {
         int k = 5;
@@ -186,11 +186,11 @@ public class RealisticBiomeBase {
             int chunkY,
             int baseX,
             int baseY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float noise[]) {}
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return 63f;
     }
 
@@ -204,7 +204,7 @@ public class RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastColdCliff.java
+++ b/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastColdCliff.java
@@ -7,7 +7,7 @@ import net.minecraft.world.biome.BiomeGenBase;
 import rwg.api.RWGBiomes;
 import rwg.biomes.realistic.RealisticBiomeBase;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeCoastColdCliff extends RealisticBiomeBase {
     public RealisticBiomeCoastColdCliff() {
@@ -20,13 +20,13 @@ public class RealisticBiomeCoastColdCliff extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {}
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         river = river > 0.5f ? 1f : river * 2f;
 
         float h = ocean < 0.5f ? ocean * 14f : 7f;
@@ -53,7 +53,7 @@ public class RealisticBiomeCoastColdCliff extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastColdSlope.java
+++ b/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastColdSlope.java
@@ -13,7 +13,7 @@ import rwg.deco.DecoGrass;
 import rwg.deco.DecoLog;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeCoastColdSlope extends RealisticBiomeBase {
     public RealisticBiomeCoastColdSlope() {
@@ -26,7 +26,7 @@ public class RealisticBiomeCoastColdSlope extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -64,7 +64,7 @@ public class RealisticBiomeCoastColdSlope extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         river = river > 0.5f ? 1f : river * 2f;
 
         float start = (perlin.noise2(x / 90f, y / 90f) * 1f)
@@ -102,7 +102,7 @@ public class RealisticBiomeCoastColdSlope extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastDunes.java
+++ b/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastDunes.java
@@ -10,7 +10,7 @@ import rwg.biomes.realistic.RealisticBiomeBase;
 import rwg.deco.DecoWaterGrass;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeCoastDunes extends RealisticBiomeBase {
     public RealisticBiomeCoastDunes() {
@@ -23,7 +23,7 @@ public class RealisticBiomeCoastDunes extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -44,7 +44,7 @@ public class RealisticBiomeCoastDunes extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         river = river > 0.5f ? 1f : river * 2f;
 
         float h = ocean < 0.5f ? ocean * 18f : 9f;
@@ -77,7 +77,7 @@ public class RealisticBiomeCoastDunes extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastIce.java
+++ b/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastIce.java
@@ -11,7 +11,7 @@ import rwg.surface.SurfaceBase;
 import rwg.surface.SurfaceGrassland;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 import rwg.util.SnowheightCalculator;
 
 public class RealisticBiomeCoastIce extends RealisticBiomeBase {
@@ -29,13 +29,13 @@ public class RealisticBiomeCoastIce extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {}
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         river = river > 0.5f ? 1f : river * 2f;
 
         float start = (perlin.noise2(x / 90f, y / 90f) * 1f)
@@ -71,7 +71,7 @@ public class RealisticBiomeCoastIce extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastMangrove.java
+++ b/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastMangrove.java
@@ -13,7 +13,7 @@ import rwg.deco.DecoWaterGrass;
 import rwg.deco.trees.DecoMangrove;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeCoastMangrove extends RealisticBiomeBase {
     public RealisticBiomeCoastMangrove() {
@@ -26,7 +26,7 @@ public class RealisticBiomeCoastMangrove extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -59,7 +59,7 @@ public class RealisticBiomeCoastMangrove extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         river = river > 0.5f ? 1f : river * 2f;
 
         float h = ocean < 0.5f ? ocean * 14f : 7f;
@@ -86,7 +86,7 @@ public class RealisticBiomeCoastMangrove extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastOasis.java
+++ b/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastOasis.java
@@ -17,7 +17,7 @@ import rwg.deco.DecoGrass;
 import rwg.deco.trees.DecoSavannah;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeCoastOasis extends RealisticBiomeBase {
     public RealisticBiomeCoastOasis() {
@@ -30,7 +30,7 @@ public class RealisticBiomeCoastOasis extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -96,7 +96,7 @@ public class RealisticBiomeCoastOasis extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         river = river > 0.5f ? 1f : river * 2f;
 
         float start = (perlin.noise2(x / 90f, y / 90f) * 1f)
@@ -134,7 +134,7 @@ public class RealisticBiomeCoastOasis extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastTest.java
+++ b/src/main/java/rwg/biomes/realistic/coast/RealisticBiomeCoastTest.java
@@ -17,7 +17,7 @@ import rwg.deco.DecoGrass;
 import rwg.deco.trees.DecoSavannah;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeCoastTest extends RealisticBiomeBase {
     public RealisticBiomeCoastTest() {
@@ -30,7 +30,7 @@ public class RealisticBiomeCoastTest extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -96,7 +96,7 @@ public class RealisticBiomeCoastTest extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         river = river > 0.5f ? 1f : river * 2f;
 
         /*float h = ocean * 10f;
@@ -146,7 +146,7 @@ public class RealisticBiomeCoastTest extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/desert/RealisticBiomeDesert.java
+++ b/src/main/java/rwg/biomes/realistic/desert/RealisticBiomeDesert.java
@@ -23,7 +23,7 @@ import rwg.surface.river.SurfaceRiverOasis;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeDesert extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -43,7 +43,7 @@ public class RealisticBiomeDesert extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -132,7 +132,7 @@ public class RealisticBiomeDesert extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -146,7 +146,7 @@ public class RealisticBiomeDesert extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/desert/RealisticBiomeDesertMountains.java
+++ b/src/main/java/rwg/biomes/realistic/desert/RealisticBiomeDesertMountains.java
@@ -23,7 +23,7 @@ import rwg.surface.river.SurfaceRiverOasis;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeDesertMountains extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -43,7 +43,7 @@ public class RealisticBiomeDesertMountains extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -132,7 +132,7 @@ public class RealisticBiomeDesertMountains extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -146,7 +146,7 @@ public class RealisticBiomeDesertMountains extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/desert/RealisticBiomeDuneValley.java
+++ b/src/main/java/rwg/biomes/realistic/desert/RealisticBiomeDuneValley.java
@@ -23,7 +23,7 @@ import rwg.surface.river.SurfaceRiverOasis;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainDunes;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeDuneValley extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -43,7 +43,7 @@ public class RealisticBiomeDuneValley extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -130,7 +130,7 @@ public class RealisticBiomeDuneValley extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -144,7 +144,7 @@ public class RealisticBiomeDuneValley extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/desert/RealisticBiomeOasis.java
+++ b/src/main/java/rwg/biomes/realistic/desert/RealisticBiomeOasis.java
@@ -24,7 +24,7 @@ import rwg.surface.river.SurfaceRiverOasis;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeOasis extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -44,7 +44,7 @@ public class RealisticBiomeOasis extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -130,7 +130,7 @@ public class RealisticBiomeOasis extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -144,7 +144,7 @@ public class RealisticBiomeOasis extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/forest/RealisticBiomeDarkRedwood.java
+++ b/src/main/java/rwg/biomes/realistic/forest/RealisticBiomeDarkRedwood.java
@@ -23,7 +23,7 @@ import rwg.surface.SurfaceMountainStoneMix1;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeDarkRedwood extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -44,7 +44,7 @@ public class RealisticBiomeDarkRedwood extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -130,7 +130,7 @@ public class RealisticBiomeDarkRedwood extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -144,7 +144,7 @@ public class RealisticBiomeDarkRedwood extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/forest/RealisticBiomeDarkRedwoodPlains.java
+++ b/src/main/java/rwg/biomes/realistic/forest/RealisticBiomeDarkRedwoodPlains.java
@@ -23,7 +23,7 @@ import rwg.surface.SurfaceMountainStoneMix1;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainGrasslandFlats;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeDarkRedwoodPlains extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -43,7 +43,7 @@ public class RealisticBiomeDarkRedwoodPlains extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -126,7 +126,7 @@ public class RealisticBiomeDarkRedwoodPlains extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -140,7 +140,7 @@ public class RealisticBiomeDarkRedwoodPlains extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/forest/RealisticBiomeWoodHills.java
+++ b/src/main/java/rwg/biomes/realistic/forest/RealisticBiomeWoodHills.java
@@ -22,7 +22,7 @@ import rwg.surface.SurfaceMountainStone;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeWoodHills extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -41,7 +41,7 @@ public class RealisticBiomeWoodHills extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -111,7 +111,7 @@ public class RealisticBiomeWoodHills extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -125,7 +125,7 @@ public class RealisticBiomeWoodHills extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/forest/RealisticBiomeWoodMountains.java
+++ b/src/main/java/rwg/biomes/realistic/forest/RealisticBiomeWoodMountains.java
@@ -22,7 +22,7 @@ import rwg.surface.SurfaceMountainSnow;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainMountainRiver;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeWoodMountains extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -41,7 +41,7 @@ public class RealisticBiomeWoodMountains extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -111,7 +111,7 @@ public class RealisticBiomeWoodMountains extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -125,7 +125,7 @@ public class RealisticBiomeWoodMountains extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeHighRainforest.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeHighRainforest.java
@@ -14,7 +14,7 @@ import rwg.surface.SurfaceGrassland;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHighland;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeHighRainforest extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -32,7 +32,7 @@ public class RealisticBiomeHighRainforest extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -48,7 +48,7 @@ public class RealisticBiomeHighRainforest extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -62,7 +62,7 @@ public class RealisticBiomeHighRainforest extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeHotRedwood.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeHotRedwood.java
@@ -25,7 +25,7 @@ import rwg.surface.SurfaceGrasslandMixBig;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainGrasslandFlats;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeHotRedwood extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -54,7 +54,7 @@ public class RealisticBiomeHotRedwood extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -159,7 +159,7 @@ public class RealisticBiomeHotRedwood extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -174,7 +174,7 @@ public class RealisticBiomeHotRedwood extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeJungleCanyon.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeJungleCanyon.java
@@ -15,7 +15,7 @@ import rwg.surface.SurfaceGrassCanyon;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainCanyon;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeJungleCanyon extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -34,7 +34,7 @@ public class RealisticBiomeJungleCanyon extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -60,7 +60,7 @@ public class RealisticBiomeJungleCanyon extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -75,7 +75,7 @@ public class RealisticBiomeJungleCanyon extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeJungleHills.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeJungleHills.java
@@ -17,7 +17,7 @@ import rwg.surface.SurfaceMountainStone;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeJungleHills extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -35,7 +35,7 @@ public class RealisticBiomeJungleHills extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -68,7 +68,7 @@ public class RealisticBiomeJungleHills extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -82,7 +82,7 @@ public class RealisticBiomeJungleHills extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomePolar.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomePolar.java
@@ -15,7 +15,7 @@ import rwg.surface.SurfacePolar;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainPolar;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomePolar extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -33,7 +33,7 @@ public class RealisticBiomePolar extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -59,7 +59,7 @@ public class RealisticBiomePolar extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -73,7 +73,7 @@ public class RealisticBiomePolar extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeRedwood.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeRedwood.java
@@ -23,7 +23,7 @@ import rwg.surface.SurfaceMountainStone;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeRedwood extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -42,7 +42,7 @@ public class RealisticBiomeRedwood extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -126,7 +126,7 @@ public class RealisticBiomeRedwood extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -140,7 +140,7 @@ public class RealisticBiomeRedwood extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeRedwoodJungle.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeRedwoodJungle.java
@@ -20,7 +20,7 @@ import rwg.surface.SurfaceGrassland;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeRedwoodJungle extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -38,7 +38,7 @@ public class RealisticBiomeRedwoodJungle extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -137,7 +137,7 @@ public class RealisticBiomeRedwoodJungle extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -151,7 +151,7 @@ public class RealisticBiomeRedwoodJungle extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeRedwoodSnow.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeRedwoodSnow.java
@@ -23,7 +23,7 @@ import rwg.surface.SurfaceMountainSnow;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeRedwoodSnow extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -42,7 +42,7 @@ public class RealisticBiomeRedwoodSnow extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -126,7 +126,7 @@ public class RealisticBiomeRedwoodSnow extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -140,7 +140,7 @@ public class RealisticBiomeRedwoodSnow extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeSnowHills.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeSnowHills.java
@@ -21,7 +21,7 @@ import rwg.surface.SurfaceMountainSnow;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainMountainSpikes;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeSnowHills extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -40,7 +40,7 @@ public class RealisticBiomeSnowHills extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -122,7 +122,7 @@ public class RealisticBiomeSnowHills extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -136,7 +136,7 @@ public class RealisticBiomeSnowHills extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeSnowLakes.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeSnowLakes.java
@@ -21,7 +21,7 @@ import rwg.surface.SurfaceMountainSnow;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainFlatLakes;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeSnowLakes extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -40,7 +40,7 @@ public class RealisticBiomeSnowLakes extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -108,7 +108,7 @@ public class RealisticBiomeSnowLakes extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -122,7 +122,7 @@ public class RealisticBiomeSnowLakes extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeSnowRivers.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeSnowRivers.java
@@ -21,7 +21,7 @@ import rwg.surface.SurfaceMountainSnow;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainMountainRiver;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeSnowRivers extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -40,7 +40,7 @@ public class RealisticBiomeSnowRivers extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -123,7 +123,7 @@ public class RealisticBiomeSnowRivers extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -137,7 +137,7 @@ public class RealisticBiomeSnowRivers extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeTaigaHills.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeTaigaHills.java
@@ -23,7 +23,7 @@ import rwg.surface.SurfaceMountainSnow;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainMountainRiver;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeTaigaHills extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -42,7 +42,7 @@ public class RealisticBiomeTaigaHills extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -126,7 +126,7 @@ public class RealisticBiomeTaigaHills extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -140,7 +140,7 @@ public class RealisticBiomeTaigaHills extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeTaigaPlains.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeTaigaPlains.java
@@ -24,7 +24,7 @@ import rwg.surface.SurfaceTundra;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainFlatLakes;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeTaigaPlains extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -43,7 +43,7 @@ public class RealisticBiomeTaigaPlains extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -143,7 +143,7 @@ public class RealisticBiomeTaigaPlains extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -157,7 +157,7 @@ public class RealisticBiomeTaigaPlains extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeTest.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeTest.java
@@ -10,7 +10,7 @@ import rwg.biomes.realistic.RealisticBiomeBase;
 import rwg.surface.SurfaceBase;
 import rwg.surface.SurfaceMountainSnow;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeTest extends RealisticBiomeBase {
     private SurfaceBase surface;
@@ -27,7 +27,7 @@ public class RealisticBiomeTest extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -136,7 +136,7 @@ public class RealisticBiomeTest extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         /*
         float pX = x;// + (perlin.noise1(y / 130f) * 80f);
         float pY = y;// + (perlin.noise1(x / 130f) * 80f);
@@ -190,7 +190,7 @@ public class RealisticBiomeTest extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeTestRiver.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeTestRiver.java
@@ -10,7 +10,7 @@ import rwg.surface.SurfaceMountainStoneMix1;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeTestRiver extends RealisticBiomeBase {
     private CellNoise celltest;
@@ -34,13 +34,13 @@ public class RealisticBiomeTestRiver extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {}
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         /*
         float pX = x + (perlin.noise1(y / 240f) * 220f);
         float pY = y + (perlin.noise1(x / 240f) * 220f);
@@ -52,7 +52,7 @@ public class RealisticBiomeTestRiver extends RealisticBiomeBase {
         return 64.1f;
     }
 
-    public float generateNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float river) {
+    public float generateNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float river) {
         float h = perlin.noise2(x / 20f, y / 20f) * 2;
         h += perlin.noise2(x / 7f, y / 7f) * 0.8f;
 

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeTundraHills.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeTundraHills.java
@@ -22,7 +22,7 @@ import rwg.surface.SurfaceTundra;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainMountain;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeTundraHills extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -41,7 +41,7 @@ public class RealisticBiomeTundraHills extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -140,7 +140,7 @@ public class RealisticBiomeTundraHills extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -154,7 +154,7 @@ public class RealisticBiomeTundraHills extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/land/RealisticBiomeTundraPlains.java
+++ b/src/main/java/rwg/biomes/realistic/land/RealisticBiomeTundraPlains.java
@@ -21,7 +21,7 @@ import rwg.surface.SurfaceTundra;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainFlatLakes;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeTundraPlains extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -40,7 +40,7 @@ public class RealisticBiomeTundraPlains extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -105,7 +105,7 @@ public class RealisticBiomeTundraPlains extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -119,7 +119,7 @@ public class RealisticBiomeTundraPlains extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/ocean/RealisticBiomeIslandTropical.java
+++ b/src/main/java/rwg/biomes/realistic/ocean/RealisticBiomeIslandTropical.java
@@ -11,7 +11,7 @@ import rwg.map.MapVolcano;
 import rwg.surface.SurfaceBase;
 import rwg.surface.SurfaceIslandMountainStone;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 import rwg.world.ChunkManagerRealistic;
 
 public class RealisticBiomeIslandTropical extends RealisticBiomeBase {
@@ -29,7 +29,7 @@ public class RealisticBiomeIslandTropical extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -118,7 +118,7 @@ public class RealisticBiomeIslandTropical extends RealisticBiomeBase {
             int baseY,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float noise[]) {
         if (baseX % 4 == 0 && baseY % 4 == 0 && mapRand.nextInt(6) == 0) {
@@ -138,7 +138,7 @@ public class RealisticBiomeIslandTropical extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float st = 15f - ((cell.noise(x / 500D, y / 500D, 1D) * 42f) + (perlin.noise2(x / 30f, y / 30f) * 2f));
 
         st = st < 0f ? 0f : st;
@@ -169,7 +169,7 @@ public class RealisticBiomeIslandTropical extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/ocean/RealisticBiomeIslandTundra.java
+++ b/src/main/java/rwg/biomes/realistic/ocean/RealisticBiomeIslandTundra.java
@@ -10,7 +10,7 @@ import rwg.biomes.realistic.RealisticBiomeBase;
 import rwg.surface.SurfaceBase;
 import rwg.surface.SurfaceIslandMountainStone;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeIslandTundra extends RealisticBiomeBase {
     private SurfaceBase surface;
@@ -27,13 +27,13 @@ public class RealisticBiomeIslandTundra extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {}
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = 0f;
 
         if (border > 0.9f) {
@@ -54,7 +54,7 @@ public class RealisticBiomeIslandTundra extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/ocean/RealisticBiomeOceanTest.java
+++ b/src/main/java/rwg/biomes/realistic/ocean/RealisticBiomeOceanTest.java
@@ -8,7 +8,7 @@ import net.minecraft.world.biome.BiomeGenBase;
 import rwg.api.RWGBiomes;
 import rwg.biomes.realistic.RealisticBiomeBase;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeOceanTest extends RealisticBiomeBase {
     public RealisticBiomeOceanTest() {
@@ -21,13 +21,13 @@ public class RealisticBiomeOceanTest extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {}
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return 45f;
     }
 
@@ -42,7 +42,7 @@ public class RealisticBiomeOceanTest extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/red/RealisticBiomeCanyon.java
+++ b/src/main/java/rwg/biomes/realistic/red/RealisticBiomeCanyon.java
@@ -19,7 +19,7 @@ import rwg.surface.SurfaceCanyon;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainCanyon;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeCanyon extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -38,7 +38,7 @@ public class RealisticBiomeCanyon extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -104,7 +104,7 @@ public class RealisticBiomeCanyon extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -119,7 +119,7 @@ public class RealisticBiomeCanyon extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/red/RealisticBiomeMesa.java
+++ b/src/main/java/rwg/biomes/realistic/red/RealisticBiomeMesa.java
@@ -24,7 +24,7 @@ import rwg.surface.river.SurfaceRiverOasis;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainMesa;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeMesa extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -45,7 +45,7 @@ public class RealisticBiomeMesa extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -145,7 +145,7 @@ public class RealisticBiomeMesa extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -159,7 +159,7 @@ public class RealisticBiomeMesa extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/red/RealisticBiomeRedDesertMountains.java
+++ b/src/main/java/rwg/biomes/realistic/red/RealisticBiomeRedDesertMountains.java
@@ -23,7 +23,7 @@ import rwg.surface.river.SurfaceRiverOasis;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeRedDesertMountains extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -43,7 +43,7 @@ public class RealisticBiomeRedDesertMountains extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -132,7 +132,7 @@ public class RealisticBiomeRedDesertMountains extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -146,7 +146,7 @@ public class RealisticBiomeRedDesertMountains extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/red/RealisticBiomeRedOasis.java
+++ b/src/main/java/rwg/biomes/realistic/red/RealisticBiomeRedOasis.java
@@ -23,7 +23,7 @@ import rwg.surface.river.SurfaceRiverOasis;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeRedOasis extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -44,7 +44,7 @@ public class RealisticBiomeRedOasis extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -129,7 +129,7 @@ public class RealisticBiomeRedOasis extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -143,7 +143,7 @@ public class RealisticBiomeRedOasis extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeCanyonForest.java
+++ b/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeCanyonForest.java
@@ -21,7 +21,7 @@ import rwg.surface.SurfaceCanyon;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainCanyon;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeCanyonForest extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -40,7 +40,7 @@ public class RealisticBiomeCanyonForest extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -163,7 +163,7 @@ public class RealisticBiomeCanyonForest extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -178,7 +178,7 @@ public class RealisticBiomeCanyonForest extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeDuneValleyForest.java
+++ b/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeDuneValleyForest.java
@@ -22,7 +22,7 @@ import rwg.surface.SurfaceDuneValley;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainDuneValley;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeDuneValleyForest extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -41,7 +41,7 @@ public class RealisticBiomeDuneValleyForest extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -151,7 +151,7 @@ public class RealisticBiomeDuneValleyForest extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -166,7 +166,7 @@ public class RealisticBiomeDuneValleyForest extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeHotForest.java
+++ b/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeHotForest.java
@@ -25,7 +25,7 @@ import rwg.surface.SurfaceGrasslandMixBig;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainGrasslandFlats;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeHotForest extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -54,7 +54,7 @@ public class RealisticBiomeHotForest extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -159,7 +159,7 @@ public class RealisticBiomeHotForest extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -174,7 +174,7 @@ public class RealisticBiomeHotForest extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeMesaPlains.java
+++ b/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeMesaPlains.java
@@ -20,7 +20,7 @@ import rwg.surface.SurfaceCanyon;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainMesa;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeMesaPlains extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -39,7 +39,7 @@ public class RealisticBiomeMesaPlains extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -111,7 +111,7 @@ public class RealisticBiomeMesaPlains extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -125,7 +125,7 @@ public class RealisticBiomeMesaPlains extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeSavanna.java
+++ b/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeSavanna.java
@@ -21,7 +21,7 @@ import rwg.surface.SurfaceGrasslandMix1;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainGrasslandFlats;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeSavanna extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -40,7 +40,7 @@ public class RealisticBiomeSavanna extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -137,7 +137,7 @@ public class RealisticBiomeSavanna extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -151,7 +151,7 @@ public class RealisticBiomeSavanna extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeSavannaDunes.java
+++ b/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeSavannaDunes.java
@@ -23,7 +23,7 @@ import rwg.surface.river.SurfaceRiverOasis;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainDuneValley;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeSavannaDunes extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -43,7 +43,7 @@ public class RealisticBiomeSavannaDunes extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -177,7 +177,7 @@ public class RealisticBiomeSavannaDunes extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -191,7 +191,7 @@ public class RealisticBiomeSavannaDunes extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeSavannaForest.java
+++ b/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeSavannaForest.java
@@ -21,7 +21,7 @@ import rwg.surface.SurfaceMountainStone;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainGrasslandMountains;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeSavannaForest extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -39,7 +39,7 @@ public class RealisticBiomeSavannaForest extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -165,7 +165,7 @@ public class RealisticBiomeSavannaForest extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -179,7 +179,7 @@ public class RealisticBiomeSavannaForest extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeStoneMountains.java
+++ b/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeStoneMountains.java
@@ -22,7 +22,7 @@ import rwg.surface.river.SurfaceRiverOasis;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeStoneMountains extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -43,7 +43,7 @@ public class RealisticBiomeStoneMountains extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -173,7 +173,7 @@ public class RealisticBiomeStoneMountains extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -187,7 +187,7 @@ public class RealisticBiomeStoneMountains extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeStoneMountainsCactus.java
+++ b/src/main/java/rwg/biomes/realistic/savanna/RealisticBiomeStoneMountainsCactus.java
@@ -22,7 +22,7 @@ import rwg.surface.river.SurfaceRiverOasis;
 import rwg.terrain.TerrainBase;
 import rwg.terrain.TerrainHilly;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeStoneMountainsCactus extends RealisticBiomeBase {
     private TerrainBase terrain;
@@ -43,7 +43,7 @@ public class RealisticBiomeStoneMountainsCactus extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -173,7 +173,7 @@ public class RealisticBiomeStoneMountainsCactus extends RealisticBiomeBase {
         }
     }
 
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -187,7 +187,7 @@ public class RealisticBiomeStoneMountainsCactus extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/commands/RwgBugInfoCommand.java
+++ b/src/main/java/rwg/commands/RwgBugInfoCommand.java
@@ -1,22 +1,13 @@
 package rwg.commands;
 
-import static net.minecraft.util.EnumChatFormatting.GOLD;
-import static net.minecraft.util.EnumChatFormatting.WHITE;
-
-import java.util.Arrays;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.ChatStyle;
+import net.minecraft.util.EnumChatFormatting;
 
 public class RwgBugInfoCommand extends CommandBase {
-    static String[] BUG_INFO_MESSAGE = {
-        "A bug in the RWG version shipped with GTNH 2.2.0.0 caused the world to be generated differently than previous versions.",
-        "The bug has since been fixed, reverting future generation to pre-2.2.0.0 style.",
-        "Unfortunately, what version was used when this world was created can't be automatically detected, so to allow players from both versions to continue playing on their world without making new ugly chunk borders, this version of RWG supports both but requires you to select which one to use when upgrading worlds.",
-        GOLD + "/rwg_noise perlin" + WHITE + " is the version used in all versions except 2.2.0.0",
-        GOLD + "/rwg_noise opensimplex" + WHITE + " is the version used in 2.2.0.0"
-    };
-
     @Override
     public String getCommandName() {
         return "rwg_buginfo";
@@ -29,7 +20,18 @@ public class RwgBugInfoCommand extends CommandBase {
 
     @Override
     public void processCommand(ICommandSender iCommandSender, String[] strings) {
-        Arrays.stream(BUG_INFO_MESSAGE).map(ChatComponentText::new).forEach(iCommandSender::addChatMessage);
+        for (int line = 1; line <= 5; line++) {
+            iCommandSender.addChatMessage(new ChatComponentTranslation("rwg.buginfo.line" + line));
+        }
+
+        iCommandSender.addChatMessage(new ChatComponentText("/rwg_noise perlin")
+                .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GOLD))
+                .appendSibling(new ChatComponentTranslation("rwg.buginfo.perlin")
+                        .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RESET))));
+        iCommandSender.addChatMessage(new ChatComponentText("/rwg_noise opensimplex")
+                .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GOLD))
+                .appendSibling(new ChatComponentTranslation("rwg.buginfo.opensimplex")
+                        .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RESET))));
     }
 
     @Override

--- a/src/main/java/rwg/commands/RwgBugInfoCommand.java
+++ b/src/main/java/rwg/commands/RwgBugInfoCommand.java
@@ -31,4 +31,14 @@ public class RwgBugInfoCommand extends CommandBase {
     public void processCommand(ICommandSender iCommandSender, String[] strings) {
         Arrays.stream(BUG_INFO_MESSAGE).map(ChatComponentText::new).forEach(iCommandSender::addChatMessage);
     }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
+    public boolean canCommandSenderUseCommand(ICommandSender sender) {
+        return true;
+    }
 }

--- a/src/main/java/rwg/commands/RwgBugInfoCommand.java
+++ b/src/main/java/rwg/commands/RwgBugInfoCommand.java
@@ -1,0 +1,34 @@
+package rwg.commands;
+
+import static net.minecraft.util.EnumChatFormatting.GOLD;
+import static net.minecraft.util.EnumChatFormatting.WHITE;
+
+import java.util.Arrays;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.util.ChatComponentText;
+
+public class RwgBugInfoCommand extends CommandBase {
+    static String[] BUG_INFO_MESSAGE = {
+        "A bug in the RWG version shipped with GTNH 2.2.0.0 caused the world to be generated differently than previous versions.",
+        "The bug has since been fixed, reverting future generation to pre-2.2.0.0 style.",
+        "Unfortunately, what version was used when this world was created can't be automatically detected, so to allow players from both versions to continue playing on their world without making new ugly chunk borders, this version of RWG supports both but requires you to select which one to use when upgrading worlds.",
+        GOLD + "/rwg_noise perlin" + WHITE + " is the version used in all versions except 2.2.0.0",
+        GOLD + "/rwg_noise opensimplex" + WHITE + " is the version used in 2.2.0.0"
+    };
+
+    @Override
+    public String getCommandName() {
+        return "rwg_buginfo";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender iCommandSender) {
+        return "/rwg_buginfo";
+    }
+
+    @Override
+    public void processCommand(ICommandSender iCommandSender, String[] strings) {
+        Arrays.stream(BUG_INFO_MESSAGE).map(ChatComponentText::new).forEach(iCommandSender::addChatMessage);
+    }
+}

--- a/src/main/java/rwg/commands/RwgNoiseCommand.java
+++ b/src/main/java/rwg/commands/RwgNoiseCommand.java
@@ -1,9 +1,13 @@
 package rwg.commands;
 
+import java.util.Locale;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
-import rwg.config.ConfigRWG;
+import net.minecraft.util.ChatComponentText;
+import rwg.util.NoiseGeneratorWrapper;
+import rwg.util.NoiseImplementation;
+import rwg.world.RwgWorldSavedData;
 
 public class RwgNoiseCommand extends CommandBase {
     @Override
@@ -13,7 +17,7 @@ public class RwgNoiseCommand extends CommandBase {
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return "/rwg_noise default|opensimplex|perlin";
+        return "/rwg_noise get|opensimplex|perlin";
     }
 
     @Override
@@ -23,6 +27,63 @@ public class RwgNoiseCommand extends CommandBase {
             throw new WrongUsageException(this.getCommandUsage(sender));
         }
 
-        ConfigRWG.setNoiseFunction(args[0]);
+        NoiseImplementation current = RwgWorldSavedData.getNoiseImplementation();
+
+        if (args[0].equals("get")) {
+            sender.addChatMessage(new ChatComponentText("Current noise type is " + current));
+            return;
+        }
+
+        NoiseImplementation noiseImplementation = NoiseImplementation.valueOf(args[0].toUpperCase(Locale.ROOT));
+        boolean wasDynamic = true;
+        switch (current) {
+            case UNKNOWN:
+            case DYNAMICPERLIN:
+            case DYNAMICOPENSIMPLEX:
+                wasDynamic = true;
+                break;
+            case PERLIN:
+            case OPENSIMPLEX:
+                wasDynamic = false;
+                break;
+        }
+
+        if (current != noiseImplementation) {
+            switch (noiseImplementation) {
+                case UNKNOWN:
+                    NoiseGeneratorWrapper.useOpenSimplex = false;
+                    sender.addChatMessage(
+                            new ChatComponentText("Set noise type to UNKNOWN, which will default to Perlin."));
+                    break;
+                case DYNAMICPERLIN:
+                    NoiseGeneratorWrapper.useOpenSimplex = false;
+                    sender.addChatMessage(new ChatComponentText("Set noise type to DYNAMICPERLIN."));
+                    break;
+                case PERLIN:
+                    NoiseGeneratorWrapper.useOpenSimplex = false;
+                    sender.addChatMessage(new ChatComponentText("Set noise type to PERLIN."));
+                    break;
+                case DYNAMICOPENSIMPLEX:
+                    NoiseGeneratorWrapper.useOpenSimplex = true;
+                    sender.addChatMessage(new ChatComponentText("Set noise type to DYNAMICOPENSIMPLEX."));
+                    break;
+                case OPENSIMPLEX:
+                    NoiseGeneratorWrapper.useOpenSimplex = true;
+                    sender.addChatMessage(new ChatComponentText("Set noise type to OPENSIMPLEX."));
+                    break;
+            }
+            if (wasDynamic) {
+                sender.addChatMessage(new ChatComponentText(
+                        "All new chunks will instantly be generated with the selected algorithm."));
+            } else {
+                sender.addChatMessage(
+                        new ChatComponentText(
+                                "World must be reloaded (server restarted or single player relog) for changes to take effect."));
+            }
+        } else {
+            sender.addChatMessage(new ChatComponentText("Noise type unchanged. "));
+        }
+
+        RwgWorldSavedData.setNoiseImplementation(noiseImplementation);
     }
 }

--- a/src/main/java/rwg/commands/RwgNoiseCommand.java
+++ b/src/main/java/rwg/commands/RwgNoiseCommand.java
@@ -4,7 +4,7 @@ import java.util.Locale;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
-import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import rwg.util.NoiseGeneratorWrapper;
 import rwg.util.NoiseImplementation;
 import rwg.world.RwgWorldSavedData;
@@ -30,12 +30,12 @@ public class RwgNoiseCommand extends CommandBase {
         NoiseImplementation current = RwgWorldSavedData.getNoiseImplementation();
 
         if (args[0].equals("get")) {
-            sender.addChatMessage(new ChatComponentText("Current noise type is " + current));
+            sender.addChatMessage(new ChatComponentTranslation("rwg.noise.current_type", current));
             return;
         }
 
         NoiseImplementation noiseImplementation = NoiseImplementation.valueOf(args[0].toUpperCase(Locale.ROOT));
-        boolean wasDynamic = true;
+        final boolean wasDynamic;
         switch (current) {
             case UNKNOWN:
             case DYNAMICPERLIN:
@@ -46,42 +46,37 @@ public class RwgNoiseCommand extends CommandBase {
             case OPENSIMPLEX:
                 wasDynamic = false;
                 break;
+            default:
+                throw new IllegalStateException(
+                        "Invalid current noise implementation value: " + noiseImplementation.toString());
         }
 
         if (current != noiseImplementation) {
             switch (noiseImplementation) {
                 case UNKNOWN:
                     NoiseGeneratorWrapper.useOpenSimplex = false;
-                    sender.addChatMessage(
-                            new ChatComponentText("Set noise type to UNKNOWN, which will default to Perlin."));
+                    sender.addChatMessage(new ChatComponentTranslation("rwg.noise.was_set_to.unknown"));
                     break;
                 case DYNAMICPERLIN:
-                    NoiseGeneratorWrapper.useOpenSimplex = false;
-                    sender.addChatMessage(new ChatComponentText("Set noise type to DYNAMICPERLIN."));
-                    break;
                 case PERLIN:
                     NoiseGeneratorWrapper.useOpenSimplex = false;
-                    sender.addChatMessage(new ChatComponentText("Set noise type to PERLIN."));
+                    sender.addChatMessage(new ChatComponentTranslation(
+                            "rwg.noise.was_set_to.generic", noiseImplementation.toString()));
                     break;
                 case DYNAMICOPENSIMPLEX:
-                    NoiseGeneratorWrapper.useOpenSimplex = true;
-                    sender.addChatMessage(new ChatComponentText("Set noise type to DYNAMICOPENSIMPLEX."));
-                    break;
                 case OPENSIMPLEX:
                     NoiseGeneratorWrapper.useOpenSimplex = true;
-                    sender.addChatMessage(new ChatComponentText("Set noise type to OPENSIMPLEX."));
+                    sender.addChatMessage(new ChatComponentTranslation(
+                            "rwg.noise.was_set_to.generic", noiseImplementation.toString()));
                     break;
             }
             if (wasDynamic) {
-                sender.addChatMessage(new ChatComponentText(
-                        "All new chunks will instantly be generated with the selected algorithm."));
+                sender.addChatMessage(new ChatComponentTranslation("rwg.noise.instant_new_chunks"));
             } else {
-                sender.addChatMessage(
-                        new ChatComponentText(
-                                "World must be reloaded (server restarted or single player relog) for changes to take effect."));
+                sender.addChatMessage(new ChatComponentTranslation("rwg.noise.needs_restart"));
             }
         } else {
-            sender.addChatMessage(new ChatComponentText("Noise type unchanged. "));
+            sender.addChatMessage(new ChatComponentTranslation("rwg.noise.unchanged"));
         }
 
         RwgWorldSavedData.setNoiseImplementation(noiseImplementation);

--- a/src/main/java/rwg/commands/RwgNoiseCommand.java
+++ b/src/main/java/rwg/commands/RwgNoiseCommand.java
@@ -1,0 +1,28 @@
+package rwg.commands;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import rwg.config.ConfigRWG;
+
+public class RwgNoiseCommand extends CommandBase {
+    @Override
+    public String getCommandName() {
+        return "rwg_noise";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/rwg_noise default|opensimplex|perlin";
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+
+        if (args.length < 1) {
+            throw new WrongUsageException(this.getCommandUsage(sender));
+        }
+
+        ConfigRWG.setNoiseFunction(args[0]);
+    }
+}

--- a/src/main/java/rwg/config/ConfigRWG.java
+++ b/src/main/java/rwg/config/ConfigRWG.java
@@ -10,6 +10,8 @@ public class ConfigRWG {
     public static boolean generateEmeralds = true;
     public static boolean enableCobblestoneBoulders = true;
 
+    public static String noiseFunction = "default";
+
     public static void init(FMLPreInitializationEvent event) {
         config = new Configuration(event.getSuggestedConfigurationFile());
 
@@ -51,6 +53,9 @@ public class ConfigRWG {
 
             generateEmeralds = config.getBoolean("Generate Emeralds", "Settings", true, "");
             enableCobblestoneBoulders = config.getBoolean("Enable Cobblestone Boulders", "Settings", true, "");
+
+            noiseFunction = config.get("","", "default", "Which noise to use. GTNH 2.2.0.0 used opensimplex, all other versions perlin.", new String[]{"default", "perlin", "opensimplex"}).getString();
+
         } catch (Exception e) {
             for (int c = 0; c < biomeIDs.length; c++) {
                 biomeIDs[c] = 200 + c;

--- a/src/main/java/rwg/config/ConfigRWG.java
+++ b/src/main/java/rwg/config/ConfigRWG.java
@@ -2,8 +2,6 @@ package rwg.config;
 
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.common.config.Configuration;
-import net.minecraftforge.common.config.Property;
-import rwg.util.NoiseGeneratorWrapper;
 
 public class ConfigRWG {
     public static Configuration config;
@@ -11,8 +9,6 @@ public class ConfigRWG {
 
     public static boolean generateEmeralds = true;
     public static boolean enableCobblestoneBoulders = true;
-
-    public static String noiseFunction = "default";
 
     public static void init(FMLPreInitializationEvent event) {
         config = new Configuration(event.getSuggestedConfigurationFile());
@@ -56,10 +52,6 @@ public class ConfigRWG {
             generateEmeralds = config.getBoolean("Generate Emeralds", "Settings", true, "");
             enableCobblestoneBoulders = config.getBoolean("Enable Cobblestone Boulders", "Settings", true, "");
 
-            noiseFunction = getNoiseGeneratorProperty().getString();
-
-            if (noiseFunction.equals("opensimplex")) NoiseGeneratorWrapper.useOpenSimplex = true;
-
         } catch (Exception e) {
             for (int c = 0; c < biomeIDs.length; c++) {
                 biomeIDs[c] = 200 + c;
@@ -68,30 +60,6 @@ public class ConfigRWG {
             if (config.hasChanged()) {
                 config.save();
             }
-        }
-    }
-
-    private static Property getNoiseGeneratorProperty() {
-        return config.get(
-                "compat",
-                "noise generator",
-                "default",
-                "Which noise to use. GTNH 2.2.0.0 used opensimplex, all other versions perlin.",
-                new String[] {"default", "perlin", "opensimplex"});
-    }
-
-    public static void setNoiseFunction(String newNoiseFunction) {
-        if (config == null) {
-            return;
-        }
-        noiseFunction = newNoiseFunction;
-        Property prop = getNoiseGeneratorProperty();
-
-        prop.set(newNoiseFunction);
-        NoiseGeneratorWrapper.useOpenSimplex = newNoiseFunction.equals("opensimplex");
-
-        if (config.hasChanged()) {
-            config.save();
         }
     }
 }

--- a/src/main/java/rwg/config/ConfigRWG.java
+++ b/src/main/java/rwg/config/ConfigRWG.java
@@ -2,6 +2,7 @@ package rwg.config;
 
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.common.config.Property;
 
 public class ConfigRWG {
     public static Configuration config;
@@ -54,13 +55,7 @@ public class ConfigRWG {
             generateEmeralds = config.getBoolean("Generate Emeralds", "Settings", true, "");
             enableCobblestoneBoulders = config.getBoolean("Enable Cobblestone Boulders", "Settings", true, "");
 
-            noiseFunction = config.get(
-                            "",
-                            "",
-                            "default",
-                            "Which noise to use. GTNH 2.2.0.0 used opensimplex, all other versions perlin.",
-                            new String[] {"default", "perlin", "opensimplex"})
-                    .getString();
+            noiseFunction = getNoiseGeneratorProperty().getString();
 
         } catch (Exception e) {
             for (int c = 0; c < biomeIDs.length; c++) {
@@ -70,6 +65,29 @@ public class ConfigRWG {
             if (config.hasChanged()) {
                 config.save();
             }
+        }
+    }
+
+    private static Property getNoiseGeneratorProperty() {
+        return config.get(
+                "compat",
+                "noise generator",
+                "default",
+                "Which noise to use. GTNH 2.2.0.0 used opensimplex, all other versions perlin.",
+                new String[] {"default", "perlin", "opensimplex"});
+    }
+
+    public static void setNoiseFunction(String newNoiseFunction) {
+        if (config == null) {
+            return;
+        }
+        noiseFunction = newNoiseFunction;
+        Property prop = getNoiseGeneratorProperty();
+
+        prop.set(newNoiseFunction);
+
+        if (config.hasChanged()) {
+            config.save();
         }
     }
 }

--- a/src/main/java/rwg/config/ConfigRWG.java
+++ b/src/main/java/rwg/config/ConfigRWG.java
@@ -54,7 +54,13 @@ public class ConfigRWG {
             generateEmeralds = config.getBoolean("Generate Emeralds", "Settings", true, "");
             enableCobblestoneBoulders = config.getBoolean("Enable Cobblestone Boulders", "Settings", true, "");
 
-            noiseFunction = config.get("","", "default", "Which noise to use. GTNH 2.2.0.0 used opensimplex, all other versions perlin.", new String[]{"default", "perlin", "opensimplex"}).getString();
+            noiseFunction = config.get(
+                            "",
+                            "",
+                            "default",
+                            "Which noise to use. GTNH 2.2.0.0 used opensimplex, all other versions perlin.",
+                            new String[] {"default", "perlin", "opensimplex"})
+                    .getString();
 
         } catch (Exception e) {
             for (int c = 0; c < biomeIDs.length; c++) {

--- a/src/main/java/rwg/config/ConfigRWG.java
+++ b/src/main/java/rwg/config/ConfigRWG.java
@@ -3,6 +3,7 @@ package rwg.config;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
+import rwg.util.NoiseGeneratorWrapper;
 
 public class ConfigRWG {
     public static Configuration config;
@@ -57,6 +58,8 @@ public class ConfigRWG {
 
             noiseFunction = getNoiseGeneratorProperty().getString();
 
+            if (noiseFunction.equals("opensimplex")) NoiseGeneratorWrapper.useOpenSimplex = true;
+
         } catch (Exception e) {
             for (int c = 0; c < biomeIDs.length; c++) {
                 biomeIDs[c] = 200 + c;
@@ -85,6 +88,7 @@ public class ConfigRWG {
         Property prop = getNoiseGeneratorProperty();
 
         prop.set(newNoiseFunction);
+        NoiseGeneratorWrapper.useOpenSimplex = newNoiseFunction.equals("opensimplex");
 
         if (config.hasChanged()) {
             config.save();

--- a/src/main/java/rwg/handlers/LoginHandler.java
+++ b/src/main/java/rwg/handlers/LoginHandler.java
@@ -7,12 +7,15 @@ public class LoginHandler {
     @SuppressWarnings("unused")
     @SubscribeEvent
     public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
+        // TODO: Figure out how to save&detect a brand new world vs. an upgraded world, and display a message
+        // conditional on that:
 
-        //        if (RwgWorldSavedData.getNoiseImplementation() == NoiseImplementation.UNKNOWN) {
-        //            event.player.addChatMessage(new ChatComponentText(RED
-        //                    + "WARNING: Unable to detect worldgen version for this world. This can cause chunk border
-        // mismatch if not corrected. Please run "
-        //                    + GOLD + "/rwg_buginfo" + WHITE + " for info on how to fix."));
-        //        }
+        /*
+        if (RwgWorldSavedData.getNoiseImplementation() == NoiseImplementation.UNKNOWN) {
+            event.player.addChatMessage(new ChatComponentText(RED
+                    + "WARNING: Unable to detect worldgen version for this world. This can cause chunk border mismatch if not corrected. Please run "
+                    + GOLD + "/rwg_buginfo" + WHITE + " for info on how to fix."));
+        }
+         */
     }
 }

--- a/src/main/java/rwg/handlers/LoginHandler.java
+++ b/src/main/java/rwg/handlers/LoginHandler.java
@@ -1,23 +1,18 @@
 package rwg.handlers;
 
-import static net.minecraft.util.EnumChatFormatting.GOLD;
-import static net.minecraft.util.EnumChatFormatting.RED;
-import static net.minecraft.util.EnumChatFormatting.WHITE;
-
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
-import net.minecraft.util.ChatComponentText;
-import rwg.util.NoiseImplementation;
-import rwg.world.RwgWorldSavedData;
 
 public class LoginHandler {
     @SuppressWarnings("unused")
     @SubscribeEvent
     public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
-        if (RwgWorldSavedData.getNoiseImplementation() == NoiseImplementation.UNKNOWN) {
-            event.player.addChatMessage(new ChatComponentText(RED
-                    + "WARNING: Unable to detect worldgen version for this world. This can cause chunk border mismatch if not corrected. Please run "
-                    + GOLD + "/rwg_buginfo" + WHITE + " for info on how to fix."));
-        }
+
+        //        if (RwgWorldSavedData.getNoiseImplementation() == NoiseImplementation.UNKNOWN) {
+        //            event.player.addChatMessage(new ChatComponentText(RED
+        //                    + "WARNING: Unable to detect worldgen version for this world. This can cause chunk border
+        // mismatch if not corrected. Please run "
+        //                    + GOLD + "/rwg_buginfo" + WHITE + " for info on how to fix."));
+        //        }
     }
 }

--- a/src/main/java/rwg/handlers/LoginHandler.java
+++ b/src/main/java/rwg/handlers/LoginHandler.java
@@ -1,0 +1,23 @@
+package rwg.handlers;
+
+import static net.minecraft.util.EnumChatFormatting.GOLD;
+import static net.minecraft.util.EnumChatFormatting.RED;
+import static net.minecraft.util.EnumChatFormatting.WHITE;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
+import net.minecraft.util.ChatComponentText;
+import rwg.util.NoiseImplementation;
+import rwg.world.RwgWorldSavedData;
+
+public class LoginHandler {
+    @SuppressWarnings("unused")
+    @SubscribeEvent
+    public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
+        if (RwgWorldSavedData.getNoiseImplementation() == NoiseImplementation.UNKNOWN) {
+            event.player.addChatMessage(new ChatComponentText(RED
+                    + "WARNING: Unable to detect worldgen version for this world. This can cause chunk border mismatch if not corrected. Please run "
+                    + GOLD + "/rwg_buginfo" + WHITE + " for info on how to fix."));
+        }
+    }
+}

--- a/src/main/java/rwg/map/MapAncientRuins.java
+++ b/src/main/java/rwg/map/MapAncientRuins.java
@@ -5,7 +5,7 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class MapAncientRuins {
     public static void build(
@@ -17,7 +17,7 @@ public class MapAncientRuins {
             int chunkY,
             int baseX,
             int baseY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             int dis) {
         int y = 120;

--- a/src/main/java/rwg/map/MapVolcano.java
+++ b/src/main/java/rwg/map/MapVolcano.java
@@ -5,7 +5,7 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 import rwg.util.TerrainMath;
 
 public class MapVolcano {
@@ -18,7 +18,7 @@ public class MapVolcano {
             int baseY,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise) {
         int i, j;

--- a/src/main/java/rwg/support/RealisticBiomeSupport.java
+++ b/src/main/java/rwg/support/RealisticBiomeSupport.java
@@ -9,7 +9,7 @@ import rwg.support.edit.EditBase;
 import rwg.surface.SurfaceBase;
 import rwg.terrain.TerrainBase;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class RealisticBiomeSupport extends RealisticBiomeBase {
     public BiomeGenBase customBiome;
@@ -52,7 +52,7 @@ public class RealisticBiomeSupport extends RealisticBiomeBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {
@@ -66,7 +66,7 @@ public class RealisticBiomeSupport extends RealisticBiomeBase {
     }
 
     @Override
-    public float rNoise(PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+    public float rNoise(NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return terrain.generateNoise(perlin, cell, x, y, ocean, border, river);
     }
 
@@ -81,7 +81,7 @@ public class RealisticBiomeSupport extends RealisticBiomeBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/support/edit/EditBase.java
+++ b/src/main/java/rwg/support/edit/EditBase.java
@@ -3,7 +3,7 @@ package rwg.support.edit;
 import java.util.Random;
 import net.minecraft.world.World;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class EditBase {
     public EditBase() {}
@@ -13,7 +13,7 @@ public class EditBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {}

--- a/src/main/java/rwg/support/edit/EditRiverOasis.java
+++ b/src/main/java/rwg/support/edit/EditRiverOasis.java
@@ -12,7 +12,7 @@ import rwg.deco.DecoFlowers;
 import rwg.deco.DecoGrass;
 import rwg.deco.trees.DecoSavannah;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class EditRiverOasis extends EditBase {
     public EditRiverOasis() {}
@@ -23,7 +23,7 @@ public class EditRiverOasis extends EditBase {
             Random rand,
             int chunkX,
             int chunkY,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float strength,
             float river) {

--- a/src/main/java/rwg/surface/SurfaceBase.java
+++ b/src/main/java/rwg/surface/SurfaceBase.java
@@ -5,7 +5,7 @@ import net.minecraft.block.Block;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceBase {
     protected Block topBlock;
@@ -26,7 +26,7 @@ public class SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceCanyon.java
+++ b/src/main/java/rwg/surface/SurfaceCanyon.java
@@ -7,6 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
+import rwg.util.NoiseGenerator;
 import rwg.util.PerlinNoise;
 
 public class SurfaceCanyon extends SurfaceBase {
@@ -20,7 +21,7 @@ public class SurfaceCanyon extends SurfaceBase {
         grassRaise = grassHeight;
 
         int[] c = new int[] {1, 8, 0};
-        PerlinNoise perlin = new PerlinNoise(2L);
+        NoiseGenerator perlin = new PerlinNoise(2L);
 
         float n;
         for (int i = 0; i < 100; i++) {
@@ -47,7 +48,7 @@ public class SurfaceCanyon extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceCanyon.java
+++ b/src/main/java/rwg/surface/SurfaceCanyon.java
@@ -18,7 +18,7 @@ public class SurfaceCanyon extends SurfaceBase {
         grassRaise = grassHeight;
 
         int[] c = new int[] {1, 8, 0};
-        NoiseGenerator perlin = NoiseSelector.CreateNoiseGenerator(2L);
+        NoiseGenerator perlin = NoiseSelector.createNoiseGenerator(2L);
 
         float n;
         for (int i = 0; i < 100; i++) {

--- a/src/main/java/rwg/surface/SurfaceCanyon.java
+++ b/src/main/java/rwg/surface/SurfaceCanyon.java
@@ -5,10 +5,7 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
-import rwg.util.CellNoise;
-import rwg.util.CliffCalculator;
-import rwg.util.NoiseGenerator;
-import rwg.util.PerlinNoise;
+import rwg.util.*;
 
 public class SurfaceCanyon extends SurfaceBase {
     private int[] claycolor = new int[100];
@@ -21,7 +18,7 @@ public class SurfaceCanyon extends SurfaceBase {
         grassRaise = grassHeight;
 
         int[] c = new int[] {1, 8, 0};
-        NoiseGenerator perlin = new PerlinNoise(2L);
+        NoiseGenerator perlin = NoiseSelector.CreateNoiseGenerator(2L);
 
         float n;
         for (int i = 0; i < 100; i++) {

--- a/src/main/java/rwg/surface/SurfaceDesert.java
+++ b/src/main/java/rwg/surface/SurfaceDesert.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceDesert extends SurfaceBase {
     private Block cliffBlock1;
@@ -33,7 +33,7 @@ public class SurfaceDesert extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceDesertMountain.java
+++ b/src/main/java/rwg/surface/SurfaceDesertMountain.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceDesertMountain extends SurfaceBase {
     private boolean beach;
@@ -55,7 +55,7 @@ public class SurfaceDesertMountain extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceDesertOasis.java
+++ b/src/main/java/rwg/surface/SurfaceDesertOasis.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceDesertOasis extends SurfaceBase {
     private Block cliffBlock1;
@@ -35,7 +35,7 @@ public class SurfaceDesertOasis extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceDuneValley.java
+++ b/src/main/java/rwg/surface/SurfaceDuneValley.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.api.RWGBiomes;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceDuneValley extends SurfaceBase {
     private float valley;
@@ -33,7 +33,7 @@ public class SurfaceDuneValley extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceGrassCanyon.java
+++ b/src/main/java/rwg/surface/SurfaceGrassCanyon.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceGrassCanyon extends SurfaceBase {
     private byte claycolor;
@@ -28,7 +28,7 @@ public class SurfaceGrassCanyon extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceGrassland.java
+++ b/src/main/java/rwg/surface/SurfaceGrassland.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceGrassland extends SurfaceBase {
     private Block cliffBlock1;
@@ -31,7 +31,7 @@ public class SurfaceGrassland extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceGrasslandMix1.java
+++ b/src/main/java/rwg/surface/SurfaceGrasslandMix1.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceGrasslandMix1 extends SurfaceBase {
     private Block mixBlock;
@@ -39,7 +39,7 @@ public class SurfaceGrasslandMix1 extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceGrasslandMixBig.java
+++ b/src/main/java/rwg/surface/SurfaceGrasslandMixBig.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceGrasslandMixBig extends SurfaceBase {
     private Block mixBlockTop;
@@ -54,7 +54,7 @@ public class SurfaceGrasslandMixBig extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceIslandMountainStone.java
+++ b/src/main/java/rwg/surface/SurfaceIslandMountainStone.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceIslandMountainStone extends SurfaceBase {
     private int beach;
@@ -55,7 +55,7 @@ public class SurfaceIslandMountainStone extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceMarshFix.java
+++ b/src/main/java/rwg/surface/SurfaceMarshFix.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceMarshFix extends SurfaceBase {
     private Block cliffBlock1;
@@ -31,7 +31,7 @@ public class SurfaceMarshFix extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceMesa.java
+++ b/src/main/java/rwg/surface/SurfaceMesa.java
@@ -5,10 +5,7 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
-import rwg.util.CellNoise;
-import rwg.util.CliffCalculator;
-import rwg.util.NoiseGenerator;
-import rwg.util.PerlinNoise;
+import rwg.util.*;
 
 public class SurfaceMesa extends SurfaceBase {
     private int[] claycolor = new int[100];
@@ -19,7 +16,7 @@ public class SurfaceMesa extends SurfaceBase {
         blockByte = b;
 
         int[] c = new int[] {1, 8, 0};
-        NoiseGenerator perlin = new PerlinNoise(2L);
+        NoiseGenerator perlin = NoiseSelector.CreateNoiseGenerator(2L);
 
         float n;
         for (int i = 0; i < 100; i++) {

--- a/src/main/java/rwg/surface/SurfaceMesa.java
+++ b/src/main/java/rwg/surface/SurfaceMesa.java
@@ -16,7 +16,7 @@ public class SurfaceMesa extends SurfaceBase {
         blockByte = b;
 
         int[] c = new int[] {1, 8, 0};
-        NoiseGenerator perlin = NoiseSelector.CreateNoiseGenerator(2L);
+        NoiseGenerator perlin = NoiseSelector.createNoiseGenerator(2L);
 
         float n;
         for (int i = 0; i < 100; i++) {

--- a/src/main/java/rwg/surface/SurfaceMesa.java
+++ b/src/main/java/rwg/surface/SurfaceMesa.java
@@ -7,6 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
+import rwg.util.NoiseGenerator;
 import rwg.util.PerlinNoise;
 
 public class SurfaceMesa extends SurfaceBase {
@@ -18,7 +19,7 @@ public class SurfaceMesa extends SurfaceBase {
         blockByte = b;
 
         int[] c = new int[] {1, 8, 0};
-        PerlinNoise perlin = new PerlinNoise(2L);
+        NoiseGenerator perlin = new PerlinNoise(2L);
 
         float n;
         for (int i = 0; i < 100; i++) {
@@ -45,7 +46,7 @@ public class SurfaceMesa extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceMountainPolar.java
+++ b/src/main/java/rwg/surface/SurfaceMountainPolar.java
@@ -5,7 +5,7 @@ import net.minecraft.block.Block;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceMountainPolar extends SurfaceBase {
     private boolean beach;
@@ -30,7 +30,7 @@ public class SurfaceMountainPolar extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceMountainSnow.java
+++ b/src/main/java/rwg/surface/SurfaceMountainSnow.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceMountainSnow extends SurfaceBase {
     private boolean beach;
@@ -64,7 +64,7 @@ public class SurfaceMountainSnow extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceMountainStone.java
+++ b/src/main/java/rwg/surface/SurfaceMountainStone.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceMountainStone extends SurfaceBase {
     private boolean beach;
@@ -57,7 +57,7 @@ public class SurfaceMountainStone extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceMountainStoneMix1.java
+++ b/src/main/java/rwg/surface/SurfaceMountainStoneMix1.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceMountainStoneMix1 extends SurfaceBase {
     private boolean beach;
@@ -61,7 +61,7 @@ public class SurfaceMountainStoneMix1 extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfacePolar.java
+++ b/src/main/java/rwg/surface/SurfacePolar.java
@@ -6,7 +6,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 import rwg.util.SnowheightCalculator;
 
 public class SurfacePolar extends SurfaceBase {
@@ -25,7 +25,7 @@ public class SurfacePolar extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceRedDesert.java
+++ b/src/main/java/rwg/surface/SurfaceRedDesert.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceRedDesert extends SurfaceBase {
     private Block cliffBlock1;
@@ -32,7 +32,7 @@ public class SurfaceRedDesert extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/SurfaceTundra.java
+++ b/src/main/java/rwg/surface/SurfaceTundra.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.util.CellNoise;
 import rwg.util.CliffCalculator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceTundra extends SurfaceBase {
     public SurfaceTundra(Block top, Block fill) {
@@ -25,7 +25,7 @@ public class SurfaceTundra extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/surface/river/SurfaceRiverOasis.java
+++ b/src/main/java/rwg/surface/river/SurfaceRiverOasis.java
@@ -7,7 +7,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import rwg.surface.SurfaceBase;
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class SurfaceRiverOasis extends SurfaceBase {
     public SurfaceRiverOasis() {
@@ -25,7 +25,7 @@ public class SurfaceRiverOasis extends SurfaceBase {
             int depth,
             World world,
             Random rand,
-            PerlinNoise perlin,
+            NoiseGenerator perlin,
             CellNoise cell,
             float[] noise,
             float river,

--- a/src/main/java/rwg/terrain/TerrainBase.java
+++ b/src/main/java/rwg/terrain/TerrainBase.java
@@ -1,13 +1,13 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainBase {
     public TerrainBase() {}
 
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         return 70f;
     }
 }

--- a/src/main/java/rwg/terrain/TerrainCanyon.java
+++ b/src/main/java/rwg/terrain/TerrainCanyon.java
@@ -1,7 +1,7 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainCanyon extends TerrainBase {
     private boolean smallRiver;
@@ -54,7 +54,7 @@ public class TerrainCanyon extends TerrainBase {
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         // float b = perlin.noise2(x / cWidth, y / cWidth) * cHeigth * river;
         // b *= b / cStrength;
         river *= 1.3f;

--- a/src/main/java/rwg/terrain/TerrainDuneValley.java
+++ b/src/main/java/rwg/terrain/TerrainDuneValley.java
@@ -1,7 +1,7 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainDuneValley extends TerrainBase {
     private float valley;
@@ -12,7 +12,7 @@ public class TerrainDuneValley extends TerrainBase {
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = (perlin.noise2(x / valley, y / valley) + 0.25f) * 65f * river;
         h = h < 1f ? 1f : h;
 

--- a/src/main/java/rwg/terrain/TerrainDunes.java
+++ b/src/main/java/rwg/terrain/TerrainDunes.java
@@ -1,13 +1,13 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainDunes extends TerrainBase {
     public TerrainDunes() {}
 
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float st = (perlin.noise2(x / 160f, y / 160f) + 0.38f) * 35f;
         st = st < 0.2f ? 0.2f : st;
 

--- a/src/main/java/rwg/terrain/TerrainFlatLakes.java
+++ b/src/main/java/rwg/terrain/TerrainFlatLakes.java
@@ -1,13 +1,13 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainFlatLakes extends TerrainBase {
     public TerrainFlatLakes() {}
 
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = perlin.noise2(x / 300f, y / 300f) * 40f * river;
         h = h > 3f ? 3f : h;
         h += perlin.noise2(x / 50f, y / 50f) * (12f - h) * 0.4f;

--- a/src/main/java/rwg/terrain/TerrainGrasslandFlats.java
+++ b/src/main/java/rwg/terrain/TerrainGrasslandFlats.java
@@ -1,14 +1,14 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainGrasslandFlats extends TerrainBase {
     public TerrainGrasslandFlats() {}
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = perlin.noise2(x / 100f, y / 100f) * 7;
         h += perlin.noise2(x / 20f, y / 20f) * 2;
 

--- a/src/main/java/rwg/terrain/TerrainGrasslandHills.java
+++ b/src/main/java/rwg/terrain/TerrainGrasslandHills.java
@@ -1,7 +1,7 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainGrasslandHills extends TerrainBase {
     private float hHeight;
@@ -48,7 +48,7 @@ public class TerrainGrasslandHills extends TerrainBase {
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = perlin.noise2(x / vWidth, y / vWidth) * vHeight * river;
         h += perlin.noise2(x / 20f, y / 20f) * 2;
 

--- a/src/main/java/rwg/terrain/TerrainGrasslandMountains.java
+++ b/src/main/java/rwg/terrain/TerrainGrasslandMountains.java
@@ -1,14 +1,14 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainGrasslandMountains extends TerrainBase {
     public TerrainGrasslandMountains() {}
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = perlin.noise2(x / 100f, y / 100f) * 7;
         h += perlin.noise2(x / 20f, y / 20f) * 2;
 

--- a/src/main/java/rwg/terrain/TerrainHighland.java
+++ b/src/main/java/rwg/terrain/TerrainHighland.java
@@ -1,7 +1,7 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainHighland extends TerrainBase {
     private float start;
@@ -18,7 +18,7 @@ public class TerrainHighland extends TerrainBase {
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = perlin.noise2(x / width, y / width) * height * river;
         h = h < start ? start + ((h - start) / 4.5f) : h;
 

--- a/src/main/java/rwg/terrain/TerrainHilly.java
+++ b/src/main/java/rwg/terrain/TerrainHilly.java
@@ -1,7 +1,7 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainHilly extends TerrainBase {
     private float width;
@@ -32,7 +32,7 @@ public class TerrainHilly extends TerrainBase {
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = perlin.noise2(x / 20f, y / 20f) * 2;
         h += perlin.noise2(x / 7f, y / 7f) * 0.8f;
 

--- a/src/main/java/rwg/terrain/TerrainMarsh.java
+++ b/src/main/java/rwg/terrain/TerrainMarsh.java
@@ -1,14 +1,14 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainMarsh extends TerrainBase {
     public TerrainMarsh() {}
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = perlin.noise2(x / 130f, y / 130f) * 30f;
 
         h += perlin.noise2(x / 12f, y / 12f) * 2f;

--- a/src/main/java/rwg/terrain/TerrainMesa.java
+++ b/src/main/java/rwg/terrain/TerrainMesa.java
@@ -1,14 +1,14 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainMesa extends TerrainBase {
     public TerrainMesa() {}
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float b = perlin.noise2(x / 130f, y / 130f) * 50f * river;
         b *= b / 40f;
 

--- a/src/main/java/rwg/terrain/TerrainMountain.java
+++ b/src/main/java/rwg/terrain/TerrainMountain.java
@@ -1,14 +1,14 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainMountain extends TerrainBase {
     public TerrainMountain() {}
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = perlin.noise2(x / 300f, y / 300f) * 135f * river;
         h *= h / 32f;
         h = h > 150f ? 150f : h;

--- a/src/main/java/rwg/terrain/TerrainMountainRiver.java
+++ b/src/main/java/rwg/terrain/TerrainMountainRiver.java
@@ -1,14 +1,14 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainMountainRiver extends TerrainBase {
     public TerrainMountainRiver() {}
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = perlin.noise2(x / 300f, y / 300f) * 135f * river;
         h *= h / 32f;
         h = h > 150f ? 150f : h;

--- a/src/main/java/rwg/terrain/TerrainMountainSpikes.java
+++ b/src/main/java/rwg/terrain/TerrainMountainSpikes.java
@@ -1,14 +1,14 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainMountainSpikes extends TerrainBase {
     public TerrainMountainSpikes() {}
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float b = (12f + (perlin.noise2(x / 300f, y / 300f) * 6f));
         float h = cell.noise(x / 200D, y / 200D, 1D) * b * river;
         h *= h * 1.5f;

--- a/src/main/java/rwg/terrain/TerrainPolar.java
+++ b/src/main/java/rwg/terrain/TerrainPolar.java
@@ -1,14 +1,14 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainPolar extends TerrainBase {
     public TerrainPolar() {}
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float st = (perlin.noise2(x / 160f, y / 160f) + 0.38f) * 35f * river;
         st = st < 0.2f ? 0.2f : st;
 

--- a/src/main/java/rwg/terrain/TerrainSmallSupport.java
+++ b/src/main/java/rwg/terrain/TerrainSmallSupport.java
@@ -1,14 +1,14 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainSmallSupport extends TerrainBase {
     public TerrainSmallSupport() {}
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = perlin.noise2(x / 100f, y / 100f) * 8;
         h += perlin.noise2(x / 30f, y / 30f) * 4;
         h += perlin.noise2(x / 15f, y / 15f) * 2;

--- a/src/main/java/rwg/terrain/TerrainSwampMountain.java
+++ b/src/main/java/rwg/terrain/TerrainSwampMountain.java
@@ -1,7 +1,7 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainSwampMountain extends TerrainBase {
     private float heigth;
@@ -14,7 +14,7 @@ public class TerrainSwampMountain extends TerrainBase {
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = perlin.noise2(x / width, y / width) * heigth * river;
         h *= h / 32f;
         h = h > 150f ? 150f : h;

--- a/src/main/java/rwg/terrain/TerrainSwampRiver.java
+++ b/src/main/java/rwg/terrain/TerrainSwampRiver.java
@@ -1,14 +1,14 @@
 package rwg.terrain;
 
 import rwg.util.CellNoise;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseGenerator;
 
 public class TerrainSwampRiver extends TerrainBase {
     public TerrainSwampRiver() {}
 
     @Override
     public float generateNoise(
-            PerlinNoise perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
+            NoiseGenerator perlin, CellNoise cell, int x, int y, float ocean, float border, float river) {
         float h = perlin.noise2(x / 180f, y / 180f) * 40f * river;
         h *= h / 35f;
 

--- a/src/main/java/rwg/util/CanyonColor.java
+++ b/src/main/java/rwg/util/CanyonColor.java
@@ -5,7 +5,7 @@ public class CanyonColor {
 
     public static void init(long l) {
         int[] c = new int[] {0, 1, 8, 14, 1, 8};
-        NoiseGenerator perlin = NoiseSelector.CreateNoiseGenerator(l);
+        NoiseGenerator perlin = NoiseSelector.createNoiseGenerator(l);
 
         float n;
         for (int i = 0; i < 256; i++) {

--- a/src/main/java/rwg/util/CanyonColor.java
+++ b/src/main/java/rwg/util/CanyonColor.java
@@ -5,7 +5,7 @@ public class CanyonColor {
 
     public static void init(long l) {
         int[] c = new int[] {0, 1, 8, 14, 1, 8};
-        NoiseGenerator perlin = new PerlinNoise(l);
+        NoiseGenerator perlin = NoiseSelector.CreateNoiseGenerator(l);
 
         float n;
         for (int i = 0; i < 256; i++) {

--- a/src/main/java/rwg/util/CanyonColor.java
+++ b/src/main/java/rwg/util/CanyonColor.java
@@ -5,7 +5,7 @@ public class CanyonColor {
 
     public static void init(long l) {
         int[] c = new int[] {0, 1, 8, 14, 1, 8};
-        PerlinNoise perlin = new PerlinNoise(l);
+        NoiseGenerator perlin = new PerlinNoise(l);
 
         float n;
         for (int i = 0; i < 256; i++) {

--- a/src/main/java/rwg/util/NoiseGenerator.java
+++ b/src/main/java/rwg/util/NoiseGenerator.java
@@ -1,0 +1,41 @@
+package rwg.util;
+
+public interface NoiseGenerator {
+    /**
+     * Computes noise function for three dimensions at the point (x,y,z).
+     *
+     * @param x x dimension parameter
+     * @param y y dimension parameter
+     * @param z z dimension parameter
+     * @return the noise value at the point (x, y, z)
+     */
+    double improvedNoise(double x, double y, double z);
+
+    /**
+     * 1-D noise generation function.
+     *
+     * @param x Seed for the noise function
+     * @return The noisy output
+     */
+    float noise1(float x);
+
+    /**
+     * Create noise in a 2D space.
+     *
+     * @param x The X coordinate of the location to sample
+     * @param y The Y coordinate of the location to sample
+     * @return A noisy value at the given position
+     */
+    float noise2(float x, float y);
+
+    /**
+     * Create noise in a 3D space.
+     *
+     * @param x The X coordinate of the location to sample
+     * @param y The Y coordinate of the location to sample
+     * @param z The Z coordinate of the location to sample
+     * @return A noisy value at the given position
+     */
+    float noise3(float x, float y, float z);
+
+}

--- a/src/main/java/rwg/util/NoiseGenerator.java
+++ b/src/main/java/rwg/util/NoiseGenerator.java
@@ -37,5 +37,4 @@ public interface NoiseGenerator {
      * @return A noisy value at the given position
      */
     float noise3(float x, float y, float z);
-
 }

--- a/src/main/java/rwg/util/NoiseGeneratorWrapper.java
+++ b/src/main/java/rwg/util/NoiseGeneratorWrapper.java
@@ -1,0 +1,36 @@
+package rwg.util;
+
+public class NoiseGeneratorWrapper implements NoiseGenerator {
+
+    NoiseGenerator innerPerlin, innerOpenSimplex;
+    public static boolean useOpenSimplex;
+
+    public NoiseGeneratorWrapper(long seed) {
+        innerPerlin = new PerlinNoise(seed);
+        innerOpenSimplex = new OpenSimplexNoise(seed);
+    }
+
+    @Override
+    public double improvedNoise(double x, double y, double z) {
+        if (useOpenSimplex) return innerOpenSimplex.improvedNoise(x, y, z);
+        return innerPerlin.improvedNoise(x, y, z);
+    }
+
+    @Override
+    public float noise1(float x) {
+        if (useOpenSimplex) return innerOpenSimplex.noise1(x);
+        return innerPerlin.noise1(x);
+    }
+
+    @Override
+    public float noise2(float x, float y) {
+        if (useOpenSimplex) return innerOpenSimplex.noise2(x, y);
+        return innerPerlin.noise2(x, y);
+    }
+
+    @Override
+    public float noise3(float x, float y, float z) {
+        if (useOpenSimplex) return innerOpenSimplex.noise3(x, y, z);
+        return innerPerlin.noise3(x, y, z);
+    }
+}

--- a/src/main/java/rwg/util/NoiseImplementation.java
+++ b/src/main/java/rwg/util/NoiseImplementation.java
@@ -1,0 +1,9 @@
+package rwg.util;
+
+public enum NoiseImplementation {
+    UNKNOWN,
+    PERLIN,
+    OPENSIMPLEX,
+    DYNAMICPERLIN,
+    DYNAMICOPENSIMPLEX
+}

--- a/src/main/java/rwg/util/NoiseSelector.java
+++ b/src/main/java/rwg/util/NoiseSelector.java
@@ -1,10 +1,20 @@
 package rwg.util;
 
+import rwg.config.ConfigRWG;
+
 public class NoiseSelector {
-    public static NoiseGenerator CreateNoiseGenerator(){
+    public static NoiseGenerator createNoiseGenerator(){
+
+        if(ConfigRWG.noiseFunction.equals("opensimplex"))
+            return new OpenSimplexNoise();
+
         return new PerlinNoise();
     }
-    public static NoiseGenerator CreateNoiseGenerator(long seed){
+    public static NoiseGenerator createNoiseGenerator(long seed){
+
+        if(ConfigRWG.noiseFunction.equals("opensimplex"))
+            return new OpenSimplexNoise(seed);
+
         return new PerlinNoise(seed);
     }
 }

--- a/src/main/java/rwg/util/NoiseSelector.java
+++ b/src/main/java/rwg/util/NoiseSelector.java
@@ -3,17 +3,16 @@ package rwg.util;
 import rwg.config.ConfigRWG;
 
 public class NoiseSelector {
-    public static NoiseGenerator createNoiseGenerator(){
+    public static NoiseGenerator createNoiseGenerator() {
 
-        if(ConfigRWG.noiseFunction.equals("opensimplex"))
-            return new OpenSimplexNoise();
+        if (ConfigRWG.noiseFunction.equals("opensimplex")) return new OpenSimplexNoise();
 
         return new PerlinNoise();
     }
-    public static NoiseGenerator createNoiseGenerator(long seed){
 
-        if(ConfigRWG.noiseFunction.equals("opensimplex"))
-            return new OpenSimplexNoise(seed);
+    public static NoiseGenerator createNoiseGenerator(long seed) {
+
+        if (ConfigRWG.noiseFunction.equals("opensimplex")) return new OpenSimplexNoise(seed);
 
         return new PerlinNoise(seed);
     }

--- a/src/main/java/rwg/util/NoiseSelector.java
+++ b/src/main/java/rwg/util/NoiseSelector.java
@@ -1,0 +1,10 @@
+package rwg.util;
+
+public class NoiseSelector {
+    public static NoiseGenerator CreateNoiseGenerator(){
+        return new PerlinNoise();
+    }
+    public static NoiseGenerator CreateNoiseGenerator(long seed){
+        return new PerlinNoise(seed);
+    }
+}

--- a/src/main/java/rwg/util/NoiseSelector.java
+++ b/src/main/java/rwg/util/NoiseSelector.java
@@ -1,19 +1,28 @@
 package rwg.util;
 
-import rwg.config.ConfigRWG;
+import rwg.world.RwgWorldSavedData;
 
 public class NoiseSelector {
-    public static NoiseGenerator createNoiseGenerator() {
-
-        if (ConfigRWG.noiseFunction.equals("opensimplex")) return new OpenSimplexNoise();
-
-        return new PerlinNoise();
-    }
-
     public static NoiseGenerator createNoiseGenerator(long seed) {
 
-        if (ConfigRWG.noiseFunction.equals("opensimplex")) return new OpenSimplexNoise(seed);
+        NoiseImplementation noiseImplementation = RwgWorldSavedData.getNoiseImplementation();
 
-        return new PerlinNoise(seed);
+        switch (noiseImplementation) {
+            case UNKNOWN:
+            case DYNAMICPERLIN:
+                NoiseGeneratorWrapper.useOpenSimplex = false;
+                return new NoiseGeneratorWrapper(seed);
+            case PERLIN:
+                NoiseGeneratorWrapper.useOpenSimplex = false;
+                return new PerlinNoise(seed);
+            case OPENSIMPLEX:
+                NoiseGeneratorWrapper.useOpenSimplex = true;
+                return new OpenSimplexNoise(seed);
+            case DYNAMICOPENSIMPLEX:
+                NoiseGeneratorWrapper.useOpenSimplex = true;
+                return new NoiseGeneratorWrapper(seed);
+        }
+
+        return new NoiseGeneratorWrapper(seed);
     }
 }

--- a/src/main/java/rwg/util/OpenSimplexNoise.java
+++ b/src/main/java/rwg/util/OpenSimplexNoise.java
@@ -5,7 +5,6 @@
  * 2D function by Kurt Spencer (With new Dodecagonal gradient set)
  * 3D function heavily optimized variant by DigitalShadow
  */
- 
 package rwg.util;
 
 /**
@@ -14,339 +13,407 @@ package rwg.util;
  */
 public class OpenSimplexNoise implements NoiseGenerator {
 
-	private static final double STRETCH_2D = -0.211324865405187;    //(1/Math.sqrt(2+1)-1)/2;
-	private static final double STRETCH_3D = -1.0 / 6.0;            //(1/Math.sqrt(3+1)-1)/3;
-	private static final double SQUISH_2D = 0.366025403784439;      //(Math.sqrt(2+1)-1)/2;
-	private static final double SQUISH_3D = 1.0 / 3.0;              //(Math.sqrt(3+1)-1)/3;
-	
-	private static final long DEFAULT_SEED = 0;
-	
-	private int[] perm;
-	private int[] perm2D;
-	private int[] perm3D;
-	
-	public OpenSimplexNoise() {
-		this(DEFAULT_SEED);
-	}
-	
-	public OpenSimplexNoise(long seed) {
-		perm = new int[256];
-		perm2D = new int[256];
-		perm3D = new int[256];
-		int[] source = new int[256];
-		for (int i = 0; i < 256; i++) {
-			source[i] = i;
-		}
-		for (int i = 255; i >= 0; i--) {
-			seed = seed * 6364136223846793005L + 1442695040888963407L;
-			int r = (int)((seed + 31) % (i + 1));
-			if (r < 0) {
-				r += (i + 1);
-			}
-			perm[i] = source[r];
-			perm2D[i] = ((perm[i] % 12) * 2);
-			perm3D[i] = ((perm[i] % 24) * 3);
-			source[r] = source[i];
-		}
-	}
-	
-	//Alias for 1D
-	public float noise1(float x) {
-		return (float)noise(x, 0.5);
-	}
-	
-	//Alias for 2D
-	public float noise2(float x, float y) {
-		return (float)noise(x, y);
-	}
-	
-	//Alias for 3D
-	public float noise3(float x, float y, float z) {
-		return (float)noise(x, y, z);
-	}
-	
-	//Alias for 3D (again)
-	public double improvedNoise(double x, double y, double z)
-	{
-		return noise(x, y, z);
-	}
-	
-	//2D OpenSimplex Noise
-	public double noise(double x, double y) {
-	
-		//Place input coordinates onto grid.
-		double stretchOffset = (x + y) * STRETCH_2D;
-		double xs = x + stretchOffset;
-		double ys = y + stretchOffset;
-		
-		//Floor to get grid coordinates of rhombus (stretched square) super-cell origin.
-		int xsb = fastFloor(xs);
-		int ysb = fastFloor(ys);
-		
-		//Skew out to get actual coordinates of rhombus origin. We'll need these later.
-		double squishOffset = (xsb + ysb) * SQUISH_2D;
-		double xb = xsb + squishOffset;
-		double yb = ysb + squishOffset;
-		
-		//Compute grid coordinates relative to rhombus origin.
-		double xins = xs - xsb;
-		double yins = ys - ysb;
-		
-		//Sum those together to get a value that determines which region we're in.
-		double inSum = xins + yins;
+    private static final double STRETCH_2D = -0.211324865405187; // (1/Math.sqrt(2+1)-1)/2;
+    private static final double STRETCH_3D = -1.0 / 6.0; // (1/Math.sqrt(3+1)-1)/3;
+    private static final double SQUISH_2D = 0.366025403784439; // (Math.sqrt(2+1)-1)/2;
+    private static final double SQUISH_3D = 1.0 / 3.0; // (Math.sqrt(3+1)-1)/3;
 
-		//Positions relative to origin point.
-		double dx0 = x - xb;
-		double dy0 = y - yb;
-		
-		//We'll be defining these inside the next block and using them afterwards.
-		double dx_ext, dy_ext;
-		int xsv_ext, ysv_ext;
-		
-		double value = 0;
+    private static final long DEFAULT_SEED = 0;
 
-		//Contribution (1,0)
-		double dx1 = dx0 - 1 - SQUISH_2D;
-		double dy1 = dy0 - 0 - SQUISH_2D;
-		double attn1 = 2 - dx1 * dx1 - dy1 * dy1;
-		if (attn1 > 0) {
-			attn1 *= attn1;
-			value += attn1 * attn1 * extrapolate2D(xsb + 1, ysb + 0, dx1, dy1);
-		}
+    private int[] perm;
+    private int[] perm2D;
+    private int[] perm3D;
 
-		//Contribution (0,1)
-		double dx2 = dx0 - 0 - SQUISH_2D;
-		double dy2 = dy0 - 1 - SQUISH_2D;
-		double attn2 = 2 - dx2 * dx2 - dy2 * dy2;
-		if (attn2 > 0) {
-			attn2 *= attn2;
-			value += attn2 * attn2 * extrapolate2D(xsb + 0, ysb + 1, dx2, dy2);
-		}
-		
-		if (inSum <= 1) { //We're inside the triangle (2-Simplex) at (0,0)
-			double zins = 1 - inSum;
-			if (zins > xins || zins > yins) { //(0,0) is one of the closest two triangular vertices
-				if (xins > yins) {
-					xsv_ext = xsb + 1;
-					ysv_ext = ysb - 1;
-					dx_ext = dx0 - 1;
-					dy_ext = dy0 + 1;
-				} else {
-					xsv_ext = xsb - 1;
-					ysv_ext = ysb + 1;
-					dx_ext = dx0 + 1;
-					dy_ext = dy0 - 1;
-				}
-			} else { //(1,0) and (0,1) are the closest two vertices.
-				xsv_ext = xsb + 1;
-				ysv_ext = ysb + 1;
-				dx_ext = dx0 - 1 - 2 * SQUISH_2D;
-				dy_ext = dy0 - 1 - 2 * SQUISH_2D;
-			}
-		} else { //We're inside the triangle (2-Simplex) at (1,1)
-			double zins = 2 - inSum;
-			if (zins < xins || zins < yins) { //(0,0) is one of the closest two triangular vertices
-				if (xins > yins) {
-					xsv_ext = xsb + 2;
-					ysv_ext = ysb + 0;
-					dx_ext = dx0 - 2 - 2 * SQUISH_2D;
-					dy_ext = dy0 + 0 - 2 * SQUISH_2D;
-				} else {
-					xsv_ext = xsb + 0;
-					ysv_ext = ysb + 2;
-					dx_ext = dx0 + 0 - 2 * SQUISH_2D;
-					dy_ext = dy0 - 2 - 2 * SQUISH_2D;
-				}
-			} else { //(1,0) and (0,1) are the closest two vertices.
-				dx_ext = dx0;
-				dy_ext = dy0;
-				xsv_ext = xsb;
-				ysv_ext = ysb;
-			}
-			xsb += 1;
-			ysb += 1;
-			dx0 = dx0 - 1 - 2 * SQUISH_2D;
-			dy0 = dy0 - 1 - 2 * SQUISH_2D;
-		}
-		
-		//Contribution (0,0) or (1,1)
-		double attn0 = 2 - dx0 * dx0 - dy0 * dy0;
-		if (attn0 > 0) {
-			attn0 *= attn0;
-			value += attn0 * attn0 * extrapolate2D(xsb, ysb, dx0, dy0);
-		}
-		
-		//Extra Vertex
-		double attn_ext = 2 - dx_ext * dx_ext - dy_ext * dy_ext;
-		if (attn_ext > 0) {
-			attn_ext *= attn_ext;
-			value += attn_ext * attn_ext * extrapolate2D(xsv_ext, ysv_ext, dx_ext, dy_ext);
-		}
-		
-		return value;
-	}
-	
-	//3D OpenSimplex Noise
-	public double noise(double x, double y, double z)
-	{
-		double stretchOffset = (x + y + z) * STRETCH_3D;
-		double xs = x + stretchOffset;
-		double ys = y + stretchOffset;
-		double zs = z + stretchOffset;
+    public OpenSimplexNoise() {
+        this(DEFAULT_SEED);
+    }
 
-		int xsb = fastFloor(xs);
-		int ysb = fastFloor(ys);
-		int zsb = fastFloor(zs);
+    public OpenSimplexNoise(long seed) {
+        perm = new int[256];
+        perm2D = new int[256];
+        perm3D = new int[256];
+        int[] source = new int[256];
+        for (int i = 0; i < 256; i++) {
+            source[i] = i;
+        }
+        for (int i = 255; i >= 0; i--) {
+            seed = seed * 6364136223846793005L + 1442695040888963407L;
+            int r = (int) ((seed + 31) % (i + 1));
+            if (r < 0) {
+                r += (i + 1);
+            }
+            perm[i] = source[r];
+            perm2D[i] = ((perm[i] % 12) * 2);
+            perm3D[i] = ((perm[i] % 24) * 3);
+            source[r] = source[i];
+        }
+    }
 
-		double squishOffset = (xsb + ysb + zsb) * SQUISH_3D;
-		double dx0 = x - (xsb + squishOffset);
-		double dy0 = y - (ysb + squishOffset);
-		double dz0 = z - (zsb + squishOffset);
+    // Alias for 1D
+    public float noise1(float x) {
+        return (float) noise(x, 0.5);
+    }
 
-		double xins = xs - xsb;
-		double yins = ys - ysb;
-		double zins = zs - zsb;
+    // Alias for 2D
+    public float noise2(float x, float y) {
+        return (float) noise(x, y);
+    }
 
-		double inSum = xins + yins + zins;
+    // Alias for 3D
+    public float noise3(float x, float y, float z) {
+        return (float) noise(x, y, z);
+    }
 
-		int hash =
-		   (int)(yins - zins + 1) |
-		   (int)(xins - yins + 1) << 1 |
-		   (int)(xins - zins + 1) << 2 |
-		   (int)inSum << 3 |
-		   (int)(inSum + zins) << 5 |
-		   (int)(inSum + yins) << 7 |
-		   (int)(inSum + xins) << 9;
+    // Alias for 3D (again)
+    public double improvedNoise(double x, double y, double z) {
+        return noise(x, y, z);
+    }
 
-		Contribution3 c = lookup3D[hash];
+    // 2D OpenSimplex Noise
+    public double noise(double x, double y) {
 
-		double value = 0.0;
-		while (c != null)
-		{
-			double dx = dx0 + c.dx;
-			double dy = dy0 + c.dy;
-			double dz = dz0 + c.dz;
-			double attn = 2 - dx * dx - dy * dy - dz * dz;
-			if (attn > 0)
-			{
-				int px = xsb + c.xsb;
-				int py = ysb + c.ysb;
-				int pz = zsb + c.zsb;
+        // Place input coordinates onto grid.
+        double stretchOffset = (x + y) * STRETCH_2D;
+        double xs = x + stretchOffset;
+        double ys = y + stretchOffset;
 
-				int i = perm3D[(perm[(perm[px & 0xFF] + py) & 0xFF] + pz) & 0xFF];
-				double valuePart = gradients3D[i] * dx + gradients3D[i + 1] * dy + gradients3D[i + 2] * dz;
+        // Floor to get grid coordinates of rhombus (stretched square) super-cell origin.
+        int xsb = fastFloor(xs);
+        int ysb = fastFloor(ys);
 
-				attn *= attn;
-				value += attn * attn * valuePart;
-			}
+        // Skew out to get actual coordinates of rhombus origin. We'll need these later.
+        double squishOffset = (xsb + ysb) * SQUISH_2D;
+        double xb = xsb + squishOffset;
+        double yb = ysb + squishOffset;
 
-			c = c.next;
-		}
-		return value;
-	}
-	
-	private double extrapolate2D(int xsb, int ysb, double dx, double dy)
-	{
-		int index = perm2D[(perm[xsb & 0xFF] + ysb) & 0xFF];
-		return gradients2D[index] * dx + gradients2D[index + 1] * dy;
-	}
-	
-	private static int fastFloor(double x) {
-		int xi = (int)x;
-		return x < xi ? xi - 1 : xi;
-	}
+        // Compute grid coordinates relative to rhombus origin.
+        double xins = xs - xsb;
+        double yins = ys - ysb;
 
-	private static Contribution3[] lookup3D;
-	
-	static {
-		int[][] base3D = new int[][] {
-			new int[] { 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1 },
-			new int[] { 2, 1, 1, 0, 2, 1, 0, 1, 2, 0, 1, 1, 3, 1, 1, 1 },
-			new int[] { 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 2, 1, 1, 0, 2, 1, 0, 1, 2, 0, 1, 1 }
-		};
-		int[] p3D = new int[] { 0, 0, 1, -1, 0, 0, 1, 0, -1, 0, 0, -1, 1, 0, 0, 0, 1, -1, 0, 0, -1, 0, 1, 0, 0, -1, 1, 0, 2, 1, 1, 0, 1, 1, 1, -1, 0, 2, 1, 0, 1, 1, 1, -1, 1, 0, 2, 0, 1, 1, 1, -1, 1, 1, 1, 3, 2, 1, 0, 3, 1, 2, 0, 1, 3, 2, 0, 1, 3, 1, 0, 2, 1, 3, 0, 2, 1, 3, 0, 1, 2, 1, 1, 1, 0, 0, 2, 2, 0, 0, 1, 1, 0, 1, 0, 2, 0, 2, 0, 1, 1, 0, 0, 1, 2, 0, 0, 2, 2, 0, 0, 0, 0, 1, 1, -1, 1, 2, 0, 0, 0, 0, 1, -1, 1, 1, 2, 0, 0, 0, 0, 1, 1, 1, -1, 2, 3, 1, 1, 1, 2, 0, 0, 2, 2, 3, 1, 1, 1, 2, 2, 0, 0, 2, 3, 1, 1, 1, 2, 0, 2, 0, 2, 1, 1, -1, 1, 2, 0, 0, 2, 2, 1, 1, -1, 1, 2, 2, 0, 0, 2, 1, -1, 1, 1, 2, 0, 0, 2, 2, 1, -1, 1, 1, 2, 0, 2, 0, 2, 1, 1, 1, -1, 2, 2, 0, 0, 2, 1, 1, 1, -1, 2, 0, 2, 0 };
-		int[] lookupPairs3D = new int[] { 0, 2, 1, 1, 2, 2, 5, 1, 6, 0, 7, 0, 32, 2, 34, 2, 129, 1, 133, 1, 160, 5, 161, 5, 518, 0, 519, 0, 546, 4, 550, 4, 645, 3, 647, 3, 672, 5, 673, 5, 674, 4, 677, 3, 678, 4, 679, 3, 680, 13, 681, 13, 682, 12, 685, 14, 686, 12, 687, 14, 712, 20, 714, 18, 809, 21, 813, 23, 840, 20, 841, 21, 1198, 19, 1199, 22, 1226, 18, 1230, 19, 1325, 23, 1327, 22, 1352, 15, 1353, 17, 1354, 15, 1357, 17, 1358, 16, 1359, 16, 1360, 11, 1361, 10, 1362, 11, 1365, 10, 1366, 9, 1367, 9, 1392, 11, 1394, 11, 1489, 10, 1493, 10, 1520, 8, 1521, 8, 1878, 9, 1879, 9, 1906, 7, 1910, 7, 2005, 6, 2007, 6, 2032, 8, 2033, 8, 2034, 7, 2037, 6, 2038, 7, 2039, 6 };
+        // Sum those together to get a value that determines which region we're in.
+        double inSum = xins + yins;
 
-		Contribution3[] contributions3D = new Contribution3[p3D.length / 9];
-		for (int i = 0; i < p3D.length; i += 9) {
-			int[] baseSet = base3D[p3D[i]];
-			Contribution3 previous = null, current = null;
-			for (int k = 0; k < baseSet.length; k += 4) {
-				current = new Contribution3(baseSet[k], baseSet[k + 1], baseSet[k + 2], baseSet[k + 3]);
-				if (previous == null) {
-					contributions3D[i / 9] = current;
-				} else {
-					previous.next = current;
-				}
-				previous = current;
-			}
-			current.next = new Contribution3(p3D[i + 1], p3D[i + 2], p3D[i + 3], p3D[i + 4]);
-			current.next.next = new Contribution3(p3D[i + 5], p3D[i + 6], p3D[i + 7], p3D[i + 8]);
-		}
-		
-		lookup3D = new Contribution3[2048];
-		for (int i = 0; i < lookupPairs3D.length; i += 2) {
-			lookup3D[lookupPairs3D[i]] = contributions3D[lookupPairs3D[i + 1]];
-		}
-	}
-	
-	//2D Gradients -- new scheme (Dodecagon)
-	private static double[] gradients2D = new double[] {
-	   0.114251372530929,   0.065963060686016,
-	   0.131926121372032,   0.000000000000000,
-	   0.114251372530929,  -0.065963060686016,
-	   0.065963060686016,  -0.114251372530929,
-	   0.000000000000000,  -0.131926121372032,
-	  -0.065963060686016,  -0.114251372530929,
-	  -0.114251372530929,  -0.065963060686016,
-	  -0.131926121372032,  -0.000000000000000,
-	  -0.114251372530929,   0.065963060686016,
-	  -0.065963060686016,   0.114251372530929,
-	  -0.000000000000000,   0.131926121372032,
-	   0.065963060686016,   0.114251372530929,
-	};
-	
-	//3D Gradients (Stretched Rhombicuboctahedron)
-	private static double[] gradients3D = new double[] {
-		-0.106796116504854,		0.0388349514563107,		0.0388349514563107,
-		-0.0388349514563107,	0.106796116504854,		0.0388349514563107,
-		-0.0388349514563107,	0.0388349514563107,		0.106796116504854,
-		0.106796116504854,		0.0388349514563107,		0.0388349514563107,
-		0.0388349514563107,		0.106796116504854,		0.0388349514563107,
-		0.0388349514563107,		0.0388349514563107,		0.106796116504854,
-		-0.106796116504854,		-0.0388349514563107,	0.0388349514563107,
-		-0.0388349514563107,	-0.106796116504854,		0.0388349514563107,
-		-0.0388349514563107,	-0.0388349514563107,	0.106796116504854,
-		0.106796116504854,		-0.0388349514563107,	0.0388349514563107,
-		0.0388349514563107,		-0.106796116504854,		0.0388349514563107,
-		0.0388349514563107,		-0.0388349514563107,	0.106796116504854,
-		-0.106796116504854,		0.0388349514563107,		-0.0388349514563107,
-		-0.0388349514563107,	0.106796116504854,		-0.0388349514563107,
-		-0.0388349514563107,	0.0388349514563107,		-0.106796116504854,
-		0.106796116504854,		0.0388349514563107,		-0.0388349514563107,
-		0.0388349514563107,		0.106796116504854,		-0.0388349514563107,
-		0.0388349514563107,		0.0388349514563107,		-0.106796116504854,
-		-0.106796116504854,		-0.0388349514563107,	-0.0388349514563107,
-		-0.0388349514563107,	-0.106796116504854,		-0.0388349514563107,
-		-0.0388349514563107,	-0.0388349514563107,	-0.106796116504854,
-		0.106796116504854,		-0.0388349514563107,	-0.0388349514563107,
-		0.0388349514563107,		-0.106796116504854,		-0.0388349514563107,
-		0.0388349514563107,		-0.0388349514563107,	-0.106796116504854,
-	};
+        // Positions relative to origin point.
+        double dx0 = x - xb;
+        double dy0 = y - yb;
 
-	private static class Contribution3 {
-		public double dx, dy, dz;
-		public int xsb, ysb, zsb;
-		public Contribution3 next;
+        // We'll be defining these inside the next block and using them afterwards.
+        double dx_ext, dy_ext;
+        int xsv_ext, ysv_ext;
 
-		public Contribution3(double multiplier, int xsb, int ysb, int zsb) {
-			dx = -xsb - multiplier * SQUISH_3D;
-			dy = -ysb - multiplier * SQUISH_3D;
-			dz = -zsb - multiplier * SQUISH_3D;
-			this.xsb = xsb;
-			this.ysb = ysb;
-			this.zsb = zsb;
-		}
-	}
+        double value = 0;
 
+        // Contribution (1,0)
+        double dx1 = dx0 - 1 - SQUISH_2D;
+        double dy1 = dy0 - 0 - SQUISH_2D;
+        double attn1 = 2 - dx1 * dx1 - dy1 * dy1;
+        if (attn1 > 0) {
+            attn1 *= attn1;
+            value += attn1 * attn1 * extrapolate2D(xsb + 1, ysb + 0, dx1, dy1);
+        }
+
+        // Contribution (0,1)
+        double dx2 = dx0 - 0 - SQUISH_2D;
+        double dy2 = dy0 - 1 - SQUISH_2D;
+        double attn2 = 2 - dx2 * dx2 - dy2 * dy2;
+        if (attn2 > 0) {
+            attn2 *= attn2;
+            value += attn2 * attn2 * extrapolate2D(xsb + 0, ysb + 1, dx2, dy2);
+        }
+
+        if (inSum <= 1) { // We're inside the triangle (2-Simplex) at (0,0)
+            double zins = 1 - inSum;
+            if (zins > xins || zins > yins) { // (0,0) is one of the closest two triangular vertices
+                if (xins > yins) {
+                    xsv_ext = xsb + 1;
+                    ysv_ext = ysb - 1;
+                    dx_ext = dx0 - 1;
+                    dy_ext = dy0 + 1;
+                } else {
+                    xsv_ext = xsb - 1;
+                    ysv_ext = ysb + 1;
+                    dx_ext = dx0 + 1;
+                    dy_ext = dy0 - 1;
+                }
+            } else { // (1,0) and (0,1) are the closest two vertices.
+                xsv_ext = xsb + 1;
+                ysv_ext = ysb + 1;
+                dx_ext = dx0 - 1 - 2 * SQUISH_2D;
+                dy_ext = dy0 - 1 - 2 * SQUISH_2D;
+            }
+        } else { // We're inside the triangle (2-Simplex) at (1,1)
+            double zins = 2 - inSum;
+            if (zins < xins || zins < yins) { // (0,0) is one of the closest two triangular vertices
+                if (xins > yins) {
+                    xsv_ext = xsb + 2;
+                    ysv_ext = ysb + 0;
+                    dx_ext = dx0 - 2 - 2 * SQUISH_2D;
+                    dy_ext = dy0 + 0 - 2 * SQUISH_2D;
+                } else {
+                    xsv_ext = xsb + 0;
+                    ysv_ext = ysb + 2;
+                    dx_ext = dx0 + 0 - 2 * SQUISH_2D;
+                    dy_ext = dy0 - 2 - 2 * SQUISH_2D;
+                }
+            } else { // (1,0) and (0,1) are the closest two vertices.
+                dx_ext = dx0;
+                dy_ext = dy0;
+                xsv_ext = xsb;
+                ysv_ext = ysb;
+            }
+            xsb += 1;
+            ysb += 1;
+            dx0 = dx0 - 1 - 2 * SQUISH_2D;
+            dy0 = dy0 - 1 - 2 * SQUISH_2D;
+        }
+
+        // Contribution (0,0) or (1,1)
+        double attn0 = 2 - dx0 * dx0 - dy0 * dy0;
+        if (attn0 > 0) {
+            attn0 *= attn0;
+            value += attn0 * attn0 * extrapolate2D(xsb, ysb, dx0, dy0);
+        }
+
+        // Extra Vertex
+        double attn_ext = 2 - dx_ext * dx_ext - dy_ext * dy_ext;
+        if (attn_ext > 0) {
+            attn_ext *= attn_ext;
+            value += attn_ext * attn_ext * extrapolate2D(xsv_ext, ysv_ext, dx_ext, dy_ext);
+        }
+
+        return value;
+    }
+
+    // 3D OpenSimplex Noise
+    public double noise(double x, double y, double z) {
+        double stretchOffset = (x + y + z) * STRETCH_3D;
+        double xs = x + stretchOffset;
+        double ys = y + stretchOffset;
+        double zs = z + stretchOffset;
+
+        int xsb = fastFloor(xs);
+        int ysb = fastFloor(ys);
+        int zsb = fastFloor(zs);
+
+        double squishOffset = (xsb + ysb + zsb) * SQUISH_3D;
+        double dx0 = x - (xsb + squishOffset);
+        double dy0 = y - (ysb + squishOffset);
+        double dz0 = z - (zsb + squishOffset);
+
+        double xins = xs - xsb;
+        double yins = ys - ysb;
+        double zins = zs - zsb;
+
+        double inSum = xins + yins + zins;
+
+        int hash = (int) (yins - zins + 1)
+                | (int) (xins - yins + 1) << 1
+                | (int) (xins - zins + 1) << 2
+                | (int) inSum << 3
+                | (int) (inSum + zins) << 5
+                | (int) (inSum + yins) << 7
+                | (int) (inSum + xins) << 9;
+
+        Contribution3 c = lookup3D[hash];
+
+        double value = 0.0;
+        while (c != null) {
+            double dx = dx0 + c.dx;
+            double dy = dy0 + c.dy;
+            double dz = dz0 + c.dz;
+            double attn = 2 - dx * dx - dy * dy - dz * dz;
+            if (attn > 0) {
+                int px = xsb + c.xsb;
+                int py = ysb + c.ysb;
+                int pz = zsb + c.zsb;
+
+                int i = perm3D[(perm[(perm[px & 0xFF] + py) & 0xFF] + pz) & 0xFF];
+                double valuePart = gradients3D[i] * dx + gradients3D[i + 1] * dy + gradients3D[i + 2] * dz;
+
+                attn *= attn;
+                value += attn * attn * valuePart;
+            }
+
+            c = c.next;
+        }
+        return value;
+    }
+
+    private double extrapolate2D(int xsb, int ysb, double dx, double dy) {
+        int index = perm2D[(perm[xsb & 0xFF] + ysb) & 0xFF];
+        return gradients2D[index] * dx + gradients2D[index + 1] * dy;
+    }
+
+    private static int fastFloor(double x) {
+        int xi = (int) x;
+        return x < xi ? xi - 1 : xi;
+    }
+
+    private static Contribution3[] lookup3D;
+
+    static {
+        int[][] base3D = new int[][] {
+            new int[] {0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1},
+            new int[] {2, 1, 1, 0, 2, 1, 0, 1, 2, 0, 1, 1, 3, 1, 1, 1},
+            new int[] {1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 2, 1, 1, 0, 2, 1, 0, 1, 2, 0, 1, 1}
+        };
+        int[] p3D = new int[] {
+            0, 0, 1, -1, 0, 0, 1, 0, -1, 0, 0, -1, 1, 0, 0, 0, 1, -1, 0, 0, -1, 0, 1, 0, 0, -1, 1, 0, 2, 1, 1, 0, 1, 1,
+            1, -1, 0, 2, 1, 0, 1, 1, 1, -1, 1, 0, 2, 0, 1, 1, 1, -1, 1, 1, 1, 3, 2, 1, 0, 3, 1, 2, 0, 1, 3, 2, 0, 1, 3,
+            1, 0, 2, 1, 3, 0, 2, 1, 3, 0, 1, 2, 1, 1, 1, 0, 0, 2, 2, 0, 0, 1, 1, 0, 1, 0, 2, 0, 2, 0, 1, 1, 0, 0, 1, 2,
+            0, 0, 2, 2, 0, 0, 0, 0, 1, 1, -1, 1, 2, 0, 0, 0, 0, 1, -1, 1, 1, 2, 0, 0, 0, 0, 1, 1, 1, -1, 2, 3, 1, 1, 1,
+            2, 0, 0, 2, 2, 3, 1, 1, 1, 2, 2, 0, 0, 2, 3, 1, 1, 1, 2, 0, 2, 0, 2, 1, 1, -1, 1, 2, 0, 0, 2, 2, 1, 1, -1,
+            1, 2, 2, 0, 0, 2, 1, -1, 1, 1, 2, 0, 0, 2, 2, 1, -1, 1, 1, 2, 0, 2, 0, 2, 1, 1, 1, -1, 2, 2, 0, 0, 2, 1, 1,
+            1, -1, 2, 0, 2, 0
+        };
+        int[] lookupPairs3D = new int[] {
+            0, 2, 1, 1, 2, 2, 5, 1, 6, 0, 7, 0, 32, 2, 34, 2, 129, 1, 133, 1, 160, 5, 161, 5, 518, 0, 519, 0, 546, 4,
+            550, 4, 645, 3, 647, 3, 672, 5, 673, 5, 674, 4, 677, 3, 678, 4, 679, 3, 680, 13, 681, 13, 682, 12, 685, 14,
+            686, 12, 687, 14, 712, 20, 714, 18, 809, 21, 813, 23, 840, 20, 841, 21, 1198, 19, 1199, 22, 1226, 18, 1230,
+            19, 1325, 23, 1327, 22, 1352, 15, 1353, 17, 1354, 15, 1357, 17, 1358, 16, 1359, 16, 1360, 11, 1361, 10,
+            1362, 11, 1365, 10, 1366, 9, 1367, 9, 1392, 11, 1394, 11, 1489, 10, 1493, 10, 1520, 8, 1521, 8, 1878, 9,
+            1879, 9, 1906, 7, 1910, 7, 2005, 6, 2007, 6, 2032, 8, 2033, 8, 2034, 7, 2037, 6, 2038, 7, 2039, 6
+        };
+
+        Contribution3[] contributions3D = new Contribution3[p3D.length / 9];
+        for (int i = 0; i < p3D.length; i += 9) {
+            int[] baseSet = base3D[p3D[i]];
+            Contribution3 previous = null, current = null;
+            for (int k = 0; k < baseSet.length; k += 4) {
+                current = new Contribution3(baseSet[k], baseSet[k + 1], baseSet[k + 2], baseSet[k + 3]);
+                if (previous == null) {
+                    contributions3D[i / 9] = current;
+                } else {
+                    previous.next = current;
+                }
+                previous = current;
+            }
+            current.next = new Contribution3(p3D[i + 1], p3D[i + 2], p3D[i + 3], p3D[i + 4]);
+            current.next.next = new Contribution3(p3D[i + 5], p3D[i + 6], p3D[i + 7], p3D[i + 8]);
+        }
+
+        lookup3D = new Contribution3[2048];
+        for (int i = 0; i < lookupPairs3D.length; i += 2) {
+            lookup3D[lookupPairs3D[i]] = contributions3D[lookupPairs3D[i + 1]];
+        }
+    }
+
+    // 2D Gradients -- new scheme (Dodecagon)
+    private static double[] gradients2D = new double[] {
+        0.114251372530929,
+        0.065963060686016,
+        0.131926121372032,
+        0.000000000000000,
+        0.114251372530929,
+        -0.065963060686016,
+        0.065963060686016,
+        -0.114251372530929,
+        0.000000000000000,
+        -0.131926121372032,
+        -0.065963060686016,
+        -0.114251372530929,
+        -0.114251372530929,
+        -0.065963060686016,
+        -0.131926121372032,
+        -0.000000000000000,
+        -0.114251372530929,
+        0.065963060686016,
+        -0.065963060686016,
+        0.114251372530929,
+        -0.000000000000000,
+        0.131926121372032,
+        0.065963060686016,
+        0.114251372530929,
+    };
+
+    // 3D Gradients (Stretched Rhombicuboctahedron)
+    private static double[] gradients3D = new double[] {
+        -0.106796116504854,
+        0.0388349514563107,
+        0.0388349514563107,
+        -0.0388349514563107,
+        0.106796116504854,
+        0.0388349514563107,
+        -0.0388349514563107,
+        0.0388349514563107,
+        0.106796116504854,
+        0.106796116504854,
+        0.0388349514563107,
+        0.0388349514563107,
+        0.0388349514563107,
+        0.106796116504854,
+        0.0388349514563107,
+        0.0388349514563107,
+        0.0388349514563107,
+        0.106796116504854,
+        -0.106796116504854,
+        -0.0388349514563107,
+        0.0388349514563107,
+        -0.0388349514563107,
+        -0.106796116504854,
+        0.0388349514563107,
+        -0.0388349514563107,
+        -0.0388349514563107,
+        0.106796116504854,
+        0.106796116504854,
+        -0.0388349514563107,
+        0.0388349514563107,
+        0.0388349514563107,
+        -0.106796116504854,
+        0.0388349514563107,
+        0.0388349514563107,
+        -0.0388349514563107,
+        0.106796116504854,
+        -0.106796116504854,
+        0.0388349514563107,
+        -0.0388349514563107,
+        -0.0388349514563107,
+        0.106796116504854,
+        -0.0388349514563107,
+        -0.0388349514563107,
+        0.0388349514563107,
+        -0.106796116504854,
+        0.106796116504854,
+        0.0388349514563107,
+        -0.0388349514563107,
+        0.0388349514563107,
+        0.106796116504854,
+        -0.0388349514563107,
+        0.0388349514563107,
+        0.0388349514563107,
+        -0.106796116504854,
+        -0.106796116504854,
+        -0.0388349514563107,
+        -0.0388349514563107,
+        -0.0388349514563107,
+        -0.106796116504854,
+        -0.0388349514563107,
+        -0.0388349514563107,
+        -0.0388349514563107,
+        -0.106796116504854,
+        0.106796116504854,
+        -0.0388349514563107,
+        -0.0388349514563107,
+        0.0388349514563107,
+        -0.106796116504854,
+        -0.0388349514563107,
+        0.0388349514563107,
+        -0.0388349514563107,
+        -0.106796116504854,
+    };
+
+    private static class Contribution3 {
+        public double dx, dy, dz;
+        public int xsb, ysb, zsb;
+        public Contribution3 next;
+
+        public Contribution3(double multiplier, int xsb, int ysb, int zsb) {
+            dx = -xsb - multiplier * SQUISH_3D;
+            dy = -ysb - multiplier * SQUISH_3D;
+            dz = -zsb - multiplier * SQUISH_3D;
+            this.xsb = xsb;
+            this.ysb = ysb;
+            this.zsb = zsb;
+        }
+    }
 }

--- a/src/main/java/rwg/util/OpenSimplexNoise.java
+++ b/src/main/java/rwg/util/OpenSimplexNoise.java
@@ -1,0 +1,352 @@
+/**
+ * Replacement noise generator that generates
+ * OpenSimplex Noise instead of Perlin Noise.
+ *
+ * 2D function by Kurt Spencer (With new Dodecagonal gradient set)
+ * 3D function heavily optimized variant by DigitalShadow
+ */
+ 
+package rwg.util;
+
+/**
+ * @author Kurt Spencer
+ * @version $Revision: 1.1$
+ */
+public class OpenSimplexNoise implements NoiseGenerator {
+
+	private static final double STRETCH_2D = -0.211324865405187;    //(1/Math.sqrt(2+1)-1)/2;
+	private static final double STRETCH_3D = -1.0 / 6.0;            //(1/Math.sqrt(3+1)-1)/3;
+	private static final double SQUISH_2D = 0.366025403784439;      //(Math.sqrt(2+1)-1)/2;
+	private static final double SQUISH_3D = 1.0 / 3.0;              //(Math.sqrt(3+1)-1)/3;
+	
+	private static final long DEFAULT_SEED = 0;
+	
+	private int[] perm;
+	private int[] perm2D;
+	private int[] perm3D;
+	
+	public OpenSimplexNoise() {
+		this(DEFAULT_SEED);
+	}
+	
+	public OpenSimplexNoise(long seed) {
+		perm = new int[256];
+		perm2D = new int[256];
+		perm3D = new int[256];
+		int[] source = new int[256];
+		for (int i = 0; i < 256; i++) {
+			source[i] = i;
+		}
+		for (int i = 255; i >= 0; i--) {
+			seed = seed * 6364136223846793005L + 1442695040888963407L;
+			int r = (int)((seed + 31) % (i + 1));
+			if (r < 0) {
+				r += (i + 1);
+			}
+			perm[i] = source[r];
+			perm2D[i] = ((perm[i] % 12) * 2);
+			perm3D[i] = ((perm[i] % 24) * 3);
+			source[r] = source[i];
+		}
+	}
+	
+	//Alias for 1D
+	public float noise1(float x) {
+		return (float)noise(x, 0.5);
+	}
+	
+	//Alias for 2D
+	public float noise2(float x, float y) {
+		return (float)noise(x, y);
+	}
+	
+	//Alias for 3D
+	public float noise3(float x, float y, float z) {
+		return (float)noise(x, y, z);
+	}
+	
+	//Alias for 3D (again)
+	public double improvedNoise(double x, double y, double z)
+	{
+		return noise(x, y, z);
+	}
+	
+	//2D OpenSimplex Noise
+	public double noise(double x, double y) {
+	
+		//Place input coordinates onto grid.
+		double stretchOffset = (x + y) * STRETCH_2D;
+		double xs = x + stretchOffset;
+		double ys = y + stretchOffset;
+		
+		//Floor to get grid coordinates of rhombus (stretched square) super-cell origin.
+		int xsb = fastFloor(xs);
+		int ysb = fastFloor(ys);
+		
+		//Skew out to get actual coordinates of rhombus origin. We'll need these later.
+		double squishOffset = (xsb + ysb) * SQUISH_2D;
+		double xb = xsb + squishOffset;
+		double yb = ysb + squishOffset;
+		
+		//Compute grid coordinates relative to rhombus origin.
+		double xins = xs - xsb;
+		double yins = ys - ysb;
+		
+		//Sum those together to get a value that determines which region we're in.
+		double inSum = xins + yins;
+
+		//Positions relative to origin point.
+		double dx0 = x - xb;
+		double dy0 = y - yb;
+		
+		//We'll be defining these inside the next block and using them afterwards.
+		double dx_ext, dy_ext;
+		int xsv_ext, ysv_ext;
+		
+		double value = 0;
+
+		//Contribution (1,0)
+		double dx1 = dx0 - 1 - SQUISH_2D;
+		double dy1 = dy0 - 0 - SQUISH_2D;
+		double attn1 = 2 - dx1 * dx1 - dy1 * dy1;
+		if (attn1 > 0) {
+			attn1 *= attn1;
+			value += attn1 * attn1 * extrapolate2D(xsb + 1, ysb + 0, dx1, dy1);
+		}
+
+		//Contribution (0,1)
+		double dx2 = dx0 - 0 - SQUISH_2D;
+		double dy2 = dy0 - 1 - SQUISH_2D;
+		double attn2 = 2 - dx2 * dx2 - dy2 * dy2;
+		if (attn2 > 0) {
+			attn2 *= attn2;
+			value += attn2 * attn2 * extrapolate2D(xsb + 0, ysb + 1, dx2, dy2);
+		}
+		
+		if (inSum <= 1) { //We're inside the triangle (2-Simplex) at (0,0)
+			double zins = 1 - inSum;
+			if (zins > xins || zins > yins) { //(0,0) is one of the closest two triangular vertices
+				if (xins > yins) {
+					xsv_ext = xsb + 1;
+					ysv_ext = ysb - 1;
+					dx_ext = dx0 - 1;
+					dy_ext = dy0 + 1;
+				} else {
+					xsv_ext = xsb - 1;
+					ysv_ext = ysb + 1;
+					dx_ext = dx0 + 1;
+					dy_ext = dy0 - 1;
+				}
+			} else { //(1,0) and (0,1) are the closest two vertices.
+				xsv_ext = xsb + 1;
+				ysv_ext = ysb + 1;
+				dx_ext = dx0 - 1 - 2 * SQUISH_2D;
+				dy_ext = dy0 - 1 - 2 * SQUISH_2D;
+			}
+		} else { //We're inside the triangle (2-Simplex) at (1,1)
+			double zins = 2 - inSum;
+			if (zins < xins || zins < yins) { //(0,0) is one of the closest two triangular vertices
+				if (xins > yins) {
+					xsv_ext = xsb + 2;
+					ysv_ext = ysb + 0;
+					dx_ext = dx0 - 2 - 2 * SQUISH_2D;
+					dy_ext = dy0 + 0 - 2 * SQUISH_2D;
+				} else {
+					xsv_ext = xsb + 0;
+					ysv_ext = ysb + 2;
+					dx_ext = dx0 + 0 - 2 * SQUISH_2D;
+					dy_ext = dy0 - 2 - 2 * SQUISH_2D;
+				}
+			} else { //(1,0) and (0,1) are the closest two vertices.
+				dx_ext = dx0;
+				dy_ext = dy0;
+				xsv_ext = xsb;
+				ysv_ext = ysb;
+			}
+			xsb += 1;
+			ysb += 1;
+			dx0 = dx0 - 1 - 2 * SQUISH_2D;
+			dy0 = dy0 - 1 - 2 * SQUISH_2D;
+		}
+		
+		//Contribution (0,0) or (1,1)
+		double attn0 = 2 - dx0 * dx0 - dy0 * dy0;
+		if (attn0 > 0) {
+			attn0 *= attn0;
+			value += attn0 * attn0 * extrapolate2D(xsb, ysb, dx0, dy0);
+		}
+		
+		//Extra Vertex
+		double attn_ext = 2 - dx_ext * dx_ext - dy_ext * dy_ext;
+		if (attn_ext > 0) {
+			attn_ext *= attn_ext;
+			value += attn_ext * attn_ext * extrapolate2D(xsv_ext, ysv_ext, dx_ext, dy_ext);
+		}
+		
+		return value;
+	}
+	
+	//3D OpenSimplex Noise
+	public double noise(double x, double y, double z)
+	{
+		double stretchOffset = (x + y + z) * STRETCH_3D;
+		double xs = x + stretchOffset;
+		double ys = y + stretchOffset;
+		double zs = z + stretchOffset;
+
+		int xsb = fastFloor(xs);
+		int ysb = fastFloor(ys);
+		int zsb = fastFloor(zs);
+
+		double squishOffset = (xsb + ysb + zsb) * SQUISH_3D;
+		double dx0 = x - (xsb + squishOffset);
+		double dy0 = y - (ysb + squishOffset);
+		double dz0 = z - (zsb + squishOffset);
+
+		double xins = xs - xsb;
+		double yins = ys - ysb;
+		double zins = zs - zsb;
+
+		double inSum = xins + yins + zins;
+
+		int hash =
+		   (int)(yins - zins + 1) |
+		   (int)(xins - yins + 1) << 1 |
+		   (int)(xins - zins + 1) << 2 |
+		   (int)inSum << 3 |
+		   (int)(inSum + zins) << 5 |
+		   (int)(inSum + yins) << 7 |
+		   (int)(inSum + xins) << 9;
+
+		Contribution3 c = lookup3D[hash];
+
+		double value = 0.0;
+		while (c != null)
+		{
+			double dx = dx0 + c.dx;
+			double dy = dy0 + c.dy;
+			double dz = dz0 + c.dz;
+			double attn = 2 - dx * dx - dy * dy - dz * dz;
+			if (attn > 0)
+			{
+				int px = xsb + c.xsb;
+				int py = ysb + c.ysb;
+				int pz = zsb + c.zsb;
+
+				int i = perm3D[(perm[(perm[px & 0xFF] + py) & 0xFF] + pz) & 0xFF];
+				double valuePart = gradients3D[i] * dx + gradients3D[i + 1] * dy + gradients3D[i + 2] * dz;
+
+				attn *= attn;
+				value += attn * attn * valuePart;
+			}
+
+			c = c.next;
+		}
+		return value;
+	}
+	
+	private double extrapolate2D(int xsb, int ysb, double dx, double dy)
+	{
+		int index = perm2D[(perm[xsb & 0xFF] + ysb) & 0xFF];
+		return gradients2D[index] * dx + gradients2D[index + 1] * dy;
+	}
+	
+	private static int fastFloor(double x) {
+		int xi = (int)x;
+		return x < xi ? xi - 1 : xi;
+	}
+
+	private static Contribution3[] lookup3D;
+	
+	static {
+		int[][] base3D = new int[][] {
+			new int[] { 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1 },
+			new int[] { 2, 1, 1, 0, 2, 1, 0, 1, 2, 0, 1, 1, 3, 1, 1, 1 },
+			new int[] { 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 2, 1, 1, 0, 2, 1, 0, 1, 2, 0, 1, 1 }
+		};
+		int[] p3D = new int[] { 0, 0, 1, -1, 0, 0, 1, 0, -1, 0, 0, -1, 1, 0, 0, 0, 1, -1, 0, 0, -1, 0, 1, 0, 0, -1, 1, 0, 2, 1, 1, 0, 1, 1, 1, -1, 0, 2, 1, 0, 1, 1, 1, -1, 1, 0, 2, 0, 1, 1, 1, -1, 1, 1, 1, 3, 2, 1, 0, 3, 1, 2, 0, 1, 3, 2, 0, 1, 3, 1, 0, 2, 1, 3, 0, 2, 1, 3, 0, 1, 2, 1, 1, 1, 0, 0, 2, 2, 0, 0, 1, 1, 0, 1, 0, 2, 0, 2, 0, 1, 1, 0, 0, 1, 2, 0, 0, 2, 2, 0, 0, 0, 0, 1, 1, -1, 1, 2, 0, 0, 0, 0, 1, -1, 1, 1, 2, 0, 0, 0, 0, 1, 1, 1, -1, 2, 3, 1, 1, 1, 2, 0, 0, 2, 2, 3, 1, 1, 1, 2, 2, 0, 0, 2, 3, 1, 1, 1, 2, 0, 2, 0, 2, 1, 1, -1, 1, 2, 0, 0, 2, 2, 1, 1, -1, 1, 2, 2, 0, 0, 2, 1, -1, 1, 1, 2, 0, 0, 2, 2, 1, -1, 1, 1, 2, 0, 2, 0, 2, 1, 1, 1, -1, 2, 2, 0, 0, 2, 1, 1, 1, -1, 2, 0, 2, 0 };
+		int[] lookupPairs3D = new int[] { 0, 2, 1, 1, 2, 2, 5, 1, 6, 0, 7, 0, 32, 2, 34, 2, 129, 1, 133, 1, 160, 5, 161, 5, 518, 0, 519, 0, 546, 4, 550, 4, 645, 3, 647, 3, 672, 5, 673, 5, 674, 4, 677, 3, 678, 4, 679, 3, 680, 13, 681, 13, 682, 12, 685, 14, 686, 12, 687, 14, 712, 20, 714, 18, 809, 21, 813, 23, 840, 20, 841, 21, 1198, 19, 1199, 22, 1226, 18, 1230, 19, 1325, 23, 1327, 22, 1352, 15, 1353, 17, 1354, 15, 1357, 17, 1358, 16, 1359, 16, 1360, 11, 1361, 10, 1362, 11, 1365, 10, 1366, 9, 1367, 9, 1392, 11, 1394, 11, 1489, 10, 1493, 10, 1520, 8, 1521, 8, 1878, 9, 1879, 9, 1906, 7, 1910, 7, 2005, 6, 2007, 6, 2032, 8, 2033, 8, 2034, 7, 2037, 6, 2038, 7, 2039, 6 };
+
+		Contribution3[] contributions3D = new Contribution3[p3D.length / 9];
+		for (int i = 0; i < p3D.length; i += 9) {
+			int[] baseSet = base3D[p3D[i]];
+			Contribution3 previous = null, current = null;
+			for (int k = 0; k < baseSet.length; k += 4) {
+				current = new Contribution3(baseSet[k], baseSet[k + 1], baseSet[k + 2], baseSet[k + 3]);
+				if (previous == null) {
+					contributions3D[i / 9] = current;
+				} else {
+					previous.next = current;
+				}
+				previous = current;
+			}
+			current.next = new Contribution3(p3D[i + 1], p3D[i + 2], p3D[i + 3], p3D[i + 4]);
+			current.next.next = new Contribution3(p3D[i + 5], p3D[i + 6], p3D[i + 7], p3D[i + 8]);
+		}
+		
+		lookup3D = new Contribution3[2048];
+		for (int i = 0; i < lookupPairs3D.length; i += 2) {
+			lookup3D[lookupPairs3D[i]] = contributions3D[lookupPairs3D[i + 1]];
+		}
+	}
+	
+	//2D Gradients -- new scheme (Dodecagon)
+	private static double[] gradients2D = new double[] {
+	   0.114251372530929,   0.065963060686016,
+	   0.131926121372032,   0.000000000000000,
+	   0.114251372530929,  -0.065963060686016,
+	   0.065963060686016,  -0.114251372530929,
+	   0.000000000000000,  -0.131926121372032,
+	  -0.065963060686016,  -0.114251372530929,
+	  -0.114251372530929,  -0.065963060686016,
+	  -0.131926121372032,  -0.000000000000000,
+	  -0.114251372530929,   0.065963060686016,
+	  -0.065963060686016,   0.114251372530929,
+	  -0.000000000000000,   0.131926121372032,
+	   0.065963060686016,   0.114251372530929,
+	};
+	
+	//3D Gradients (Stretched Rhombicuboctahedron)
+	private static double[] gradients3D = new double[] {
+		-0.106796116504854,		0.0388349514563107,		0.0388349514563107,
+		-0.0388349514563107,	0.106796116504854,		0.0388349514563107,
+		-0.0388349514563107,	0.0388349514563107,		0.106796116504854,
+		0.106796116504854,		0.0388349514563107,		0.0388349514563107,
+		0.0388349514563107,		0.106796116504854,		0.0388349514563107,
+		0.0388349514563107,		0.0388349514563107,		0.106796116504854,
+		-0.106796116504854,		-0.0388349514563107,	0.0388349514563107,
+		-0.0388349514563107,	-0.106796116504854,		0.0388349514563107,
+		-0.0388349514563107,	-0.0388349514563107,	0.106796116504854,
+		0.106796116504854,		-0.0388349514563107,	0.0388349514563107,
+		0.0388349514563107,		-0.106796116504854,		0.0388349514563107,
+		0.0388349514563107,		-0.0388349514563107,	0.106796116504854,
+		-0.106796116504854,		0.0388349514563107,		-0.0388349514563107,
+		-0.0388349514563107,	0.106796116504854,		-0.0388349514563107,
+		-0.0388349514563107,	0.0388349514563107,		-0.106796116504854,
+		0.106796116504854,		0.0388349514563107,		-0.0388349514563107,
+		0.0388349514563107,		0.106796116504854,		-0.0388349514563107,
+		0.0388349514563107,		0.0388349514563107,		-0.106796116504854,
+		-0.106796116504854,		-0.0388349514563107,	-0.0388349514563107,
+		-0.0388349514563107,	-0.106796116504854,		-0.0388349514563107,
+		-0.0388349514563107,	-0.0388349514563107,	-0.106796116504854,
+		0.106796116504854,		-0.0388349514563107,	-0.0388349514563107,
+		0.0388349514563107,		-0.106796116504854,		-0.0388349514563107,
+		0.0388349514563107,		-0.0388349514563107,	-0.106796116504854,
+	};
+
+	private static class Contribution3 {
+		public double dx, dy, dz;
+		public int xsb, ysb, zsb;
+		public Contribution3 next;
+
+		public Contribution3(double multiplier, int xsb, int ysb, int zsb) {
+			dx = -xsb - multiplier * SQUISH_3D;
+			dy = -ysb - multiplier * SQUISH_3D;
+			dz = -zsb - multiplier * SQUISH_3D;
+			this.xsb = xsb;
+			this.ysb = ysb;
+			this.zsb = zsb;
+		}
+	}
+
+}

--- a/src/main/java/rwg/util/PerlinNoise.java
+++ b/src/main/java/rwg/util/PerlinNoise.java
@@ -28,7 +28,7 @@ import java.util.Random;
  * @author Justin Couch
  * @version $Revision: 1.4 $
  */
-public class PerlinNoise {
+public class PerlinNoise implements NoiseGenerator {
     private Random rand;
 
     // Constants for setting up the Perlin-1 noise functions
@@ -95,6 +95,7 @@ public class PerlinNoise {
      * @param z z dimension parameter
      * @return the noise value at the point (x, y, z)
      */
+    @java.lang.Override
     public double improvedNoise(double x, double y, double z) {
         // Constraint the point to a unit cube
         int uc_x = (int) Math.floor(x) & 255;
@@ -140,6 +141,7 @@ public class PerlinNoise {
      * @param x Seed for the noise function
      * @return The noisy output
      */
+    @java.lang.Override
     public float noise1(float x) {
         float t = x + N;
         int bx0 = ((int) t) & BM;
@@ -162,6 +164,7 @@ public class PerlinNoise {
      * @param y The Y coordinate of the location to sample
      * @return A noisy value at the given position
      */
+    @java.lang.Override
     public float noise2(float x, float y) {
         float t = x + N;
         int bx0 = ((int) t) & BM;
@@ -209,6 +212,7 @@ public class PerlinNoise {
      * @param z The Z coordinate of the location to sample
      * @return A noisy value at the given position
      */
+    @java.lang.Override
     public float noise3(float x, float y, float z) {
         float t = x + (float) N;
         int bx0 = ((int) t) & BM;

--- a/src/main/java/rwg/world/ChunkGeneratorRealistic.java
+++ b/src/main/java/rwg/world/ChunkGeneratorRealistic.java
@@ -90,7 +90,7 @@ public class ChunkGeneratorRealistic implements IChunkProvider {
         cmr = (ChunkManagerRealistic) worldObj.getWorldChunkManager();
 
         rand = new Random(l);
-        perlin = NoiseSelector.CreateNoiseGenerator(l);
+        perlin = NoiseSelector.createNoiseGenerator(l);
         cell = new CellNoise(l, (short) 0);
         cell.setUseDistance(true);
 

--- a/src/main/java/rwg/world/ChunkGeneratorRealistic.java
+++ b/src/main/java/rwg/world/ChunkGeneratorRealistic.java
@@ -39,10 +39,7 @@ import net.minecraftforge.event.terraingen.TerrainGen;
 import rwg.biomes.realistic.RealisticBiomeBase;
 import rwg.config.ConfigRWG;
 import rwg.deco.DecoClay;
-import rwg.util.CanyonColor;
-import rwg.util.CellNoise;
-import rwg.util.NoiseGenerator;
-import rwg.util.PerlinNoise;
+import rwg.util.*;
 
 public class ChunkGeneratorRealistic implements IChunkProvider {
     private Random rand;
@@ -93,7 +90,7 @@ public class ChunkGeneratorRealistic implements IChunkProvider {
         cmr = (ChunkManagerRealistic) worldObj.getWorldChunkManager();
 
         rand = new Random(l);
-        perlin = new PerlinNoise(l);
+        perlin = NoiseSelector.CreateNoiseGenerator(l);
         cell = new CellNoise(l, (short) 0);
         cell.setUseDistance(true);
 

--- a/src/main/java/rwg/world/ChunkGeneratorRealistic.java
+++ b/src/main/java/rwg/world/ChunkGeneratorRealistic.java
@@ -41,6 +41,7 @@ import rwg.config.ConfigRWG;
 import rwg.deco.DecoClay;
 import rwg.util.CanyonColor;
 import rwg.util.CellNoise;
+import rwg.util.NoiseGenerator;
 import rwg.util.PerlinNoise;
 
 public class ChunkGeneratorRealistic implements IChunkProvider {
@@ -54,7 +55,7 @@ public class ChunkGeneratorRealistic implements IChunkProvider {
     private final MapGenMineshaft mineshaftGenerator;
     private final MapGenVillage villageGenerator;
 
-    private PerlinNoise perlin;
+    private NoiseGenerator perlin;
     private CellNoise cell;
 
     private RealisticBiomeBase[] biomesForGeneration;

--- a/src/main/java/rwg/world/ChunkManagerRealistic.java
+++ b/src/main/java/rwg/world/ChunkManagerRealistic.java
@@ -11,16 +11,16 @@ import net.minecraft.world.biome.BiomeCache;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.biome.WorldChunkManager;
 import rwg.biomes.realistic.RealisticBiomeBase;
-import rwg.biomes.realistic.land.*;
 import rwg.support.Support;
 import rwg.util.CellNoise;
+import rwg.util.NoiseGenerator;
 import rwg.util.PerlinNoise;
 
 public class ChunkManagerRealistic extends WorldChunkManager {
     private BiomeCache biomeCache;
     private List biomesToSpawnIn;
 
-    private PerlinNoise perlin;
+    private NoiseGenerator perlin;
     private CellNoise cell;
 
     private CellNoise biomecell;

--- a/src/main/java/rwg/world/ChunkManagerRealistic.java
+++ b/src/main/java/rwg/world/ChunkManagerRealistic.java
@@ -14,7 +14,7 @@ import rwg.biomes.realistic.RealisticBiomeBase;
 import rwg.support.Support;
 import rwg.util.CellNoise;
 import rwg.util.NoiseGenerator;
-import rwg.util.PerlinNoise;
+import rwg.util.NoiseSelector;
 
 public class ChunkManagerRealistic extends WorldChunkManager {
     private BiomeCache biomeCache;
@@ -53,7 +53,7 @@ public class ChunkManagerRealistic extends WorldChunkManager {
         this();
         long seed = par1World.getSeed();
 
-        perlin = new PerlinNoise(seed);
+        perlin = NoiseSelector.CreateNoiseGenerator(seed);
         cell = new CellNoise(seed, (short) 0);
         cell.setUseDistance(true);
         biomecell = new CellNoise(seed, (short) 0);

--- a/src/main/java/rwg/world/ChunkManagerRealistic.java
+++ b/src/main/java/rwg/world/ChunkManagerRealistic.java
@@ -53,7 +53,7 @@ public class ChunkManagerRealistic extends WorldChunkManager {
         this();
         long seed = par1World.getSeed();
 
-        perlin = NoiseSelector.CreateNoiseGenerator(seed);
+        perlin = NoiseSelector.createNoiseGenerator(seed);
         cell = new CellNoise(seed, (short) 0);
         cell.setUseDistance(true);
         biomecell = new CellNoise(seed, (short) 0);

--- a/src/main/java/rwg/world/RwgWorldSavedData.java
+++ b/src/main/java/rwg/world/RwgWorldSavedData.java
@@ -1,0 +1,81 @@
+package rwg.world;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.WorldSavedData;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.storage.MapStorage;
+import net.minecraftforge.common.DimensionManager;
+import rwg.util.NoiseImplementation;
+
+public class RwgWorldSavedData extends WorldSavedData {
+    private static RwgWorldSavedData INSTANCE = null;
+    private static final String DATA_NAME = "rwg_data";
+    private NoiseImplementation noiseImplementation = rwg.util.NoiseImplementation.UNKNOWN;
+
+    public RwgWorldSavedData() {
+        super(DATA_NAME);
+    }
+
+    public RwgWorldSavedData(String s) {
+        super(s);
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound nbtTagCompound) {
+        String noiseImplementation = nbtTagCompound.getString("noiseImplementation");
+
+        System.out.println("RWG LOADING DATA - NOISE STRING: " + noiseImplementation);
+        try {
+            this.noiseImplementation = NoiseImplementation.valueOf(noiseImplementation);
+        } catch (IllegalArgumentException e) {
+            System.out.println("RWG ERROR LOADING DATA - NOISE IS: " + this.noiseImplementation);
+        }
+    }
+
+    @Override
+    public void writeToNBT(NBTTagCompound nbtTagCompound) {
+        String noiseString = noiseImplementation.toString();
+
+        System.out.println("RWG SAVING DATA DATA - NOISE: " + noiseImplementation);
+        System.out.println("RWG SAVING DATA DATA - NOISE: " + noiseString);
+        try {
+            nbtTagCompound.setString("noiseImplementation", noiseString);
+        } catch (Exception e) {
+            System.out.println("RWG ERROR SAVING DATA - NOISE IS: " + this.noiseImplementation);
+        }
+    }
+
+    static void loadInstance() {
+        if (INSTANCE == null) {
+            WorldServer world = DimensionManager.getWorld(0);
+            if (world == null) return;
+
+            MapStorage storage = world.mapStorage;
+            if (storage == null) return;
+
+            INSTANCE = (RwgWorldSavedData) storage.loadData(RwgWorldSavedData.class, DATA_NAME);
+            if (INSTANCE == null) {
+                INSTANCE = new RwgWorldSavedData();
+                storage.setData(DATA_NAME, INSTANCE);
+            }
+        }
+        INSTANCE.markDirty();
+    }
+
+    public static void setNoiseImplementation(NoiseImplementation ni) {
+        loadInstance();
+
+        System.out.println("RWG SETTING NOISE: " + ni);
+        INSTANCE.noiseImplementation = ni;
+    }
+
+    public static NoiseImplementation getNoiseImplementation() {
+        loadInstance();
+        if (INSTANCE == null) {
+            System.out.println("RWG COULD NOT LOAD GENERATION DATA - RETURNING UNKNOWN");
+            return NoiseImplementation.UNKNOWN;
+        }
+
+        return INSTANCE.noiseImplementation;
+    }
+}

--- a/src/main/resources/assets/rwg/lang/en_US.lang
+++ b/src/main/resources/assets/rwg/lang/en_US.lang
@@ -1,1 +1,15 @@
 generator.RWG=Realistic Alpha
+rwg.buginfo.line1=A bug in the RWG version shipped with GTNH 2.2.0.0 caused the world to be generated differently than previous versions.
+rwg.buginfo.line2=The bug has since been fixed, reverting future generation to pre-2.2.0.0 style.
+rwg.buginfo.line3=Unfortunately, what version was used when this world was created can't be automatically detected.
+rwg.buginfo.line4=To allow players from both versions to continue playing on their world without making new ugly chunk borders,
+rwg.buginfo.line5=this version of RWG supports both but requires you to select which one to use when upgrading worlds.
+rwg.buginfo.perlin= is the version used in all versions except 2.2.0.0
+rwg.buginfo.opensimplex= is the version used in 2.2.0.0
+
+rwg.noise.current_type=Current noise type is %s
+rwg.noise.unchanged=Noise type unchanged.
+rwg.noise.was_set_to.unknown=Noise type was set to UNKNOWN, which will default to Perlin.
+rwg.noise.was_set_to.generic=Noise type was set to %s
+rwg.noise.instant_new_chunks=All new chunks will instantly be generated with the selected algorithm.
+rwg.noise.needs_restart=World must be reloaded (server restarted or single player relog) for changes to take effect.


### PR DESCRIPTION
GTNH 2.2.0.0 unintentionally introduced a change to world gen caused by using our own build of RWG, which turned out to have 7 years old changes in its source code that were not in the CurseForge binary we had been using until now. This change has been reverted to avoid ugly chunk borders in worlds upgrading from a previous GTNH version, but said revert will instead cause those chunk borders whenever a world created in 2.2.0.0 is updated to the next version. This PR introduces a way to switch between the two through a config option or ingame command (/rwg_noise <default|opensimplex|perlin>).