### PR TITLE
Fix broken terrain gen after -28675

### DIFF
--- a/src/main/java/rwg/world/ChunkGeneratorRealistic.java
+++ b/src/main/java/rwg/world/ChunkGeneratorRealistic.java
@@ -215,6 +215,9 @@ public class ChunkGeneratorRealistic implements IChunkProvider {
 
     public float[] getNewNoise(ChunkManagerRealistic cmr, int x, int y, RealisticBiomeBase biomes[]) {
         int i, j, k, l, m, n, p;
+        // fixes broken chunk gen (from Bartworks ASM)
+        if (x < -28675) x %= -28675;
+        if (y < -28675) y %= -28675;
 
         for (i = -sampleSize; i < sampleSize + 5; i++) {
             for (j = -sampleSize; j < sampleSize + 5; j++) {


### PR DESCRIPTION
Ported from ASM from Bartworks
Removed from Bartworks in https://github.com/GTNewHorizons/bartworks/pull/371

Before  
![image](https://github.com/GTNewHorizons/Realistic-World-Gen/assets/18713839/2d7bbf58-55e6-4f18-8b6e-ef51cd7984b9)


After  
![image](https://github.com/GTNewHorizons/Realistic-World-Gen/assets/18713839/b3577ccc-5b45-4157-b1ab-eddda1c7e7da)
