### PR TITLE
Fix broken terrain gen past -20480 in either X or Z

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,12 +1,13 @@
 // Add your dependencies here
 
 dependencies {
+    runtimeOnlyNonPublishable("curse.maven:journeymap-32274:4500658")
     compile("com.github.GTNewHorizons:NotEnoughItems:2.4.12-GTNH:dev")
 
     devOnlyNonPublishable('curse.maven:biomes-o-plenty-220318:2499612')
     compileOnly('curse.maven:extrabiomesxl-60041:2273301')
 
     //runtimeOnlyNonPublishable('com.github.GTNewHorizons:Climate-Control:0.10.0-GTNH:dev')
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:CodeChickenCore:1.1.11:dev')
+    devOnlyNonPublishable('com.github.GTNewHorizons:CodeChickenCore:1.1.11:dev')
     runtimeOnlyNonPublishable("curse.maven:chunkpregenerator-267193:3790102")
 }

--- a/src/main/java/rwg/util/PerlinNoise.java
+++ b/src/main/java/rwg/util/PerlinNoise.java
@@ -143,6 +143,7 @@ public class PerlinNoise implements NoiseGenerator {
     @java.lang.Override
     public float noise1(float x) {
         float t = x + N;
+        t = Math.abs(t);
         int bx0 = ((int) t) & BM;
         int bx1 = (bx0 + 1) & BM;
         float rx0 = t - (int) t;
@@ -166,12 +167,14 @@ public class PerlinNoise implements NoiseGenerator {
     @java.lang.Override
     public float noise2(float x, float y) {
         float t = x + N;
+        t = Math.abs(t);
         int bx0 = ((int) t) & BM;
         int bx1 = (bx0 + 1) & BM;
         float rx0 = t - (int) t;
         float rx1 = rx0 - 1;
 
         t = y + N;
+        t = Math.abs(t);
         int by0 = ((int) t) & BM;
         int by1 = (by0 + 1) & BM;
         float ry0 = t - (int) t;
@@ -214,18 +217,21 @@ public class PerlinNoise implements NoiseGenerator {
     @java.lang.Override
     public float noise3(float x, float y, float z) {
         float t = x + (float) N;
+        t = Math.abs(t);
         int bx0 = ((int) t) & BM;
         int bx1 = (bx0 + 1) & BM;
         float rx0 = (float) (t - (int) t);
         float rx1 = rx0 - 1;
 
         t = y + (float) N;
+        t = Math.abs(t);
         int by0 = ((int) t) & BM;
         int by1 = (by0 + 1) & BM;
         float ry0 = (float) (t - (int) t);
         float ry1 = ry0 - 1;
 
         t = z + (float) N;
+        t = Math.abs(t);
         int bz0 = ((int) t) & BM;
         int bz1 = (bz0 + 1) & BM;
         float rz0 = (float) (t - (int) t);

--- a/src/main/java/rwg/world/ChunkGeneratorRealistic.java
+++ b/src/main/java/rwg/world/ChunkGeneratorRealistic.java
@@ -215,9 +215,6 @@ public class ChunkGeneratorRealistic implements IChunkProvider {
 
     public float[] getNewNoise(ChunkManagerRealistic cmr, int x, int y, RealisticBiomeBase biomes[]) {
         int i, j, k, l, m, n, p;
-        // fixes broken chunk gen (from Bartworks ASM)
-        if (x < -28675) x %= -28675;
-        if (y < -28675) y %= -28675;
 
         for (i = -sampleSize; i < sampleSize + 5; i++) {
             for (j = -sampleSize; j < sampleSize + 5; j++) {

--- a/src/main/java/rwg/world/ChunkManagerRealistic.java
+++ b/src/main/java/rwg/world/ChunkManagerRealistic.java
@@ -328,6 +328,7 @@ public class ChunkManagerRealistic extends WorldChunkManager {
     }
 
     public float calculateRiver(int x, int y, float st, float biomeHeight) {
+
         if (st < 0f && biomeHeight > 59f) {
             float pX = x + (perlin.noise1(y / 240f) * 220f);
             float pY = y + (perlin.noise1(x / 240f) * 220f);


### PR DESCRIPTION
Because this is worldgen related, a large amount of testing will need to be done.


Initial thoughts:
Issue appears to rest in the `PerlinNoise` class's `noise1/noise2/noise3` methods.

Example from `noise2`:

Example of how its called: `h += perlin.noise2(x / 12f, y / 12f) * 3f;`

`N = 0x1000 (4096)`
`BM = 0xff (255)`
```java
float t = x + N;
int bx0 = ((int) t) & BM;
int bx1 = (bx0 + 1) & BM;
float rx0 = t - (int) t;
float rx1 = rx0 - 1;
```

If x is less than -4096 then t still remains negative which causes much higher numbers to be returned.



Example images:
50 chunk circle generated at -20480,-20480 with 0 fixes (including no cyclical world gen from bartworks)
If you look around the edges of the circle, you can see the fixed terrain gen
![image](https://github.com/GTNewHorizons/Realistic-World-Gen/assets/18713839/c565e1fd-231f-4aac-b281-09b10a35854d)

Facing west past -20480x
![2023-12-19_00 35 14](https://github.com/GTNewHorizons/Realistic-World-Gen/assets/18713839/f9ff623b-098e-41bd-af24-02aa697f5a6e)

Facing north past -20480z
![2023-12-19_00 35 35](https://github.com/GTNewHorizons/Realistic-World-Gen/assets/18713839/9bf1a6b0-6aa3-4f17-90f4-70266115bd9f)

In the north west past -20480x, -20480z is the worst
![2023-12-19_00 36 51](https://github.com/GTNewHorizons/Realistic-World-Gen/assets/18713839/0f931774-10e5-45da-ae39-879bf14a06de)

Terrain gen with the fix in place in the north west
![2023-12-19_00 37 31](https://github.com/GTNewHorizons/Realistic-World-Gen/assets/18713839/eaa5f37e-50e8-4b07-9ae7-de5be061ee47)

and in the west
![2023-12-19_00 40 46](https://github.com/GTNewHorizons/Realistic-World-Gen/assets/18713839/93ff2c08-3862-4755-b4e8-b4d51d6eb937)

